### PR TITLE
fix: Allow hosting within nested paths

### DIFF
--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -15,7 +15,7 @@ module.exports = (playroomConfig, options) => {
     entry: require.resolve('../src/index.js'),
     output: {
       path: path.resolve(playroomConfig.cwd, playroomConfig.outputPath),
-      publicPath: '/'
+      publicPath: ''
     },
     resolve: {
       alias: {


### PR DESCRIPTION
By setting the `publicPath` to a blank string, the generated files can be hosted within nested paths. Otherwise, right now, the generated HTML will attempt to resolve files relative to the root URL.