### PR TITLE
fix: Open correct URL if custom port is supplied

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -17,12 +17,13 @@ module.exports = (config, callback) => {
 
   const compiler = webpack(webpackConfig);
   const devServer = new WebpackDevServer(compiler, webpackDevServerConfig);
+  const { port = 9000 } = config;
 
-  devServer.listen(config.port || 9000, 'localhost', (...args) => {
+  devServer.listen(port, 'localhost', (...args) => {
     const [err] = args;
 
     if (!err) {
-      opn('http://localhost:9000');
+      opn(`http://localhost:${port}`);
     }
 
     if (typeof callback === 'function') {


### PR DESCRIPTION
- With a config key `port`
