### PR TITLE
fix(build): Handle build errors

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -72,6 +72,7 @@ const showUsage = () => {
   if (playroom.hasOwnProperty(args.command)) {
     playroom[args.command](err => {
       if (err) {
+        console.error(err);
         process.exit(1);
       }
     });

--- a/lib/build.js
+++ b/lib/build.js
@@ -14,8 +14,8 @@ module.exports = (config, callback = noop) => {
       return callback(errorMessage);
     }
 
-    const info = stats.toJson();
     if (stats.hasErrors()) {
+      const info = stats.toJson();
       return callback(info.errors.join('\n\n'));
     }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,12 +1,24 @@
 const webpack = require('webpack');
 const makeWebpackConfig = require('./makeWebpackConfig');
+const noop = () => {};
 
-module.exports = (config, callback) => {
+module.exports = (config, callback = noop) => {
   const webpackConfig = makeWebpackConfig(config, { production: true });
 
-  webpack(webpackConfig, (...args) => {
-    if (typeof callback === 'function') {
-      callback(...args);
+  webpack(webpackConfig, (err, stats) => {
+    // https://webpack.js.org/api/node/#error-handling
+    if (err) {
+      const errorMessage = [err.stack || err, err.details]
+        .filter(Boolean)
+        .join('/n/n');
+      return callback(errorMessage);
     }
+
+    const info = stats.toJson();
+    if (stats.hasErrors()) {
+      return callback(info.errors.join('\n\n'));
+    }
+
+    return callback();
   });
 };


### PR DESCRIPTION
This fixes two issues with `playroom build`:
- In the case of an error, it wasn't being logged to the terminal.
- Only errors with webpack itself were being caught, not errors with the code being compiled. For example, a syntax error in your component library wouldn't fail the build.