### PR TITLE
feat: Add default webpack config, compile with Babel and support JSX

### DIFF
--- a/examples/material-ui/playroom.config.js
+++ b/examples/material-ui/playroom.config.js
@@ -9,22 +9,5 @@ module.exports = {
     <Badge badgeContent="2" color="primary">
       <Button color="primary">Hello</Button>
     </Badge>
-  `,
-  webpackConfig: () => ({
-    module: {
-      rules: [
-        {
-          test: /\.js$/,
-          include: __dirname,
-          exclude: /node_modules/,
-          use: {
-            loader: 'babel-loader',
-            options: {
-              presets: ['@babel/preset-env', '@babel/preset-react']
-            }
-          }
-        }
-      ]
-    }
-  })
+  `
 };

--- a/examples/reakit/playroom.config.js
+++ b/examples/reakit/playroom.config.js
@@ -9,22 +9,5 @@ module.exports = {
       <Button maxWidth="20vmin">Up</Button>
       <Button maxWidth="20vmin">Down</Button>
     </Group>
-  `,
-  webpackConfig: () => ({
-    module: {
-      rules: [
-        {
-          test: /\.js$/,
-          include: __dirname,
-          exclude: /node_modules/,
-          use: {
-            loader: 'babel-loader',
-            options: {
-              presets: ['@babel/preset-env', '@babel/preset-react']
-            }
-          }
-        }
-      ]
-    }
-  })
+  `
 };

--- a/lib/makeDefaultWebpackConfig.js
+++ b/lib/makeDefaultWebpackConfig.js
@@ -1,0 +1,20 @@
+module.exports = playroomConfig => ({
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        include: playroomConfig.cwd,
+        exclude: /node_modules/,
+        use: {
+          loader: require.resolve('babel-loader'),
+          options: {
+            presets: [
+              require.resolve('@babel/preset-env'),
+              require.resolve('@babel/preset-react')
+            ]
+          }
+        }
+      }
+    ]
+  }
+});

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -7,6 +7,7 @@ const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 const playroomPath = path.resolve(__dirname, '..');
 const examplesPath = path.resolve(playroomPath, 'examples');
 const localNodeModulesPath = path.resolve(playroomPath, 'node_modules');
+const makeDefaultWebpackConfig = require('./makeDefaultWebpackConfig');
 
 module.exports = (playroomConfig, options) => {
   const relativeResolve = requirePath =>
@@ -103,7 +104,7 @@ module.exports = (playroomConfig, options) => {
 
   const theirConfig = playroomConfig.webpackConfig
     ? playroomConfig.webpackConfig()
-    : {};
+    : makeDefaultWebpackConfig(playroomConfig);
 
   return merge(ourConfig, theirConfig);
 };


### PR DESCRIPTION
As you can see in the updated examples, this fixes an issue where you need to provide custom webpack config just to use modules and JSX in your configuration code. This ensures that you get a sensible baseline level of compilation for your source code, but allows you to easily override it when needed.

I'm planning to expand this further in the future, but this is an obvious starting point.