### PR TITLE
fix: Fix syntax highlighting and autocomplete

### DIFF
--- a/src/Playroom/Playroom.js
+++ b/src/Playroom/Playroom.js
@@ -15,20 +15,13 @@ import { store } from '../index';
 import WindowPortal from './WindowPortal';
 import UndockSvg from '../assets/icons/NewWindowSvg';
 
-// CodeMirror blows up in a Node context, so only execute it in the browser
-const ReactCodeMirror =
-  typeof window === 'undefined'
-    ? null
-    : (() => {
-        const lib = require('react-codemirror');
-        require('codemirror/mode/jsx/jsx');
-        require('codemirror/addon/edit/closetag');
-        require('codemirror/addon/edit/closebrackets');
-        require('codemirror/addon/hint/show-hint');
-        require('codemirror/addon/hint/xml-hint');
-
-        return lib;
-      })();
+import codeMirror from 'codemirror';
+import ReactCodeMirror from 'react-codemirror';
+import 'codemirror/mode/jsx/jsx';
+import 'codemirror/addon/edit/closetag';
+import 'codemirror/addon/edit/closebrackets';
+import 'codemirror/addon/hint/show-hint';
+import 'codemirror/addon/hint/xml-hint';
 
 const resizableConfig = {
   top: true,
@@ -244,6 +237,7 @@ export default class Playroom extends Component {
           >
             <div className={styles.undockedEditorContainer}>
               <ReactCodeMirror
+                codeMirrorInstance={codeMirror}
                 ref={this.storeCodeMirrorRef}
                 value={code}
                 onChange={this.handleChange}
@@ -307,6 +301,7 @@ export default class Playroom extends Component {
             />
           </div>
           <ReactCodeMirror
+            codeMirrorInstance={codeMirror}
             ref={this.storeCodeMirrorRef}
             value={code}
             onChange={this.handleChange}


### PR DESCRIPTION
Since react-codemirror calls `require('codemirror')` internally, it's possible that it ends up referencing a different version of CodeMirror than we expect. This manifests itself in syntax highlighting and autocomplete failing to work.

The fix for this is to explicitly pass in our own reference to CodeMirror, via the `codeMirrorInstance` prop. This ensures that `require('codemirror')` is no longer called by react-codemirror, and we're in full control of the version being used.

I've also refactored the code to use regular imports rather than using `require` because we no longer need to guard against rendering in a Node context (this is a relic from when Playroom used to be part of our pre-rendered style guide site), and it would have been really awkward to solve this using the existing strategy.