### PR TITLE
fix: Disable chunk sorting in HtmlWebpackPlugin

### DIFF
--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -103,7 +103,8 @@ module.exports = async (playroomConfig, options) => {
       new HtmlWebpackPlugin({
         title: playroomConfig.title
           ? `Playroom | ${playroomConfig.title}`
-          : 'Playroom'
+          : 'Playroom',
+        chunksSortMode: 'none'
       }),
       ...(options.production ? [] : [new FriendlyErrorsWebpackPlugin()])
     ],


### PR DESCRIPTION
Webpack >= 4 doesn't need chunks to be sorted, and this option can cause builds to fail with errors that are difficult to debug.

In my case Webpack created circularly dependent chunks even after removing any circular imports in the module graph. As I mentioned above, the error that gets thrown is especially unhelpful:

```
$project/node_modules/toposort/index.j
s:35
      throw new Error('Cyclic dependency' + nodeRep)
      ^

Error: Cyclic dependency
    at visit ($project/node_modules/toposort/index.js:35:13)
<-- snipped about 30 more stack frames -->
```

With a bit of research I found https://github.com/jantimon/html-webpack-plugin/issues/870#issuecomment-370004105 which suggests `chunksSortMode: 'none'` as a workaround, and I've verified this prevents the error for my project. It also seems that this has been made the default in https://github.com/jantimon/html-webpack-plugin/pull/953, but that change hasn't made it's way into an official release yet, so I'd greatly appreciate it if this small patch could be merged/released faster here.