### PR TITLE
Custom JSX support

### DIFF
--- a/src/Playroom/RenderJsx/RenderJsx.js
+++ b/src/Playroom/RenderJsx/RenderJsx.js
@@ -28,7 +28,12 @@ export default class RenderJsx extends Component {
 
     const fragment = `<React.Fragment>${jsx.trim() ||
       '<React.Fragment />'}</React.Fragment>`;
-    const { code } = transform(fragment);
+    const { code } = transform(fragment, {
+      jsx:
+        typeof scope.createElement === 'function'
+          ? 'createElement'
+          : 'React.createElement'
+    });
     const el = scopeEval(code, { ...scope, React, this: this });
 
     return el;


### PR DESCRIPTION
### What

This PR makes it possible for users to easily override `React.createElement` with a function of their choice.

### Why

I'm using [Emotion](https://emotion.sh) for CSS in my project, with their Babel plugin that replaces calls to `React.createElement` with calls to Emotions own `jsx` function. Bublé has a `jsx` configuration option that allows you to accomplish the same thing, but Playroom didn't expose any way to set it.

### Design note

I opted for detecting a `createElement` global in the user provided scope, rather than exposing the Bublé option directly or adding anything in the playroom config file. I see the following benefits to this approach:

 - Makes it simple for users to pull in whatever dependencies they need to power their JSX compilation. E.g. my playroom components file has the line `export { jsx as createElement } from '@emotion/core'`.
- Relatively straightforward to implement, no need to pass extra configuration through the Playroom component tree.
- Less configuration options => less things to get wrong when setting it up.