### PR TITLE
fix: Support types from files outside of cwd

### DIFF
--- a/lib/getStaticTypes.js
+++ b/lib/getStaticTypes.js
@@ -20,7 +20,7 @@ module.exports = async playroomConfig => {
     typeScriptFiles = ['**/*.{ts,tsx}', '!**/node_modules']
   } = playroomConfig;
 
-  const tsConfigPath = await findUp('tsconfig.json', { cwd, absolute: true });
+  const tsConfigPath = await findUp('tsconfig.json', { cwd });
 
   if (!tsConfigPath) {
     return {};
@@ -30,7 +30,7 @@ module.exports = async playroomConfig => {
     const { parse } = require('react-docgen-typescript').withCustomConfig(
       tsConfigPath
     );
-    const files = await fastGlob(typeScriptFiles, { cwd });
+    const files = await fastGlob(typeScriptFiles, { cwd, absolute: true });
     const types = parse(files);
     const typesByDisplayName = keyBy(types, 'displayName');
     const parsedTypes = mapValues(typesByDisplayName, component =>

--- a/lib/getStaticTypes.js
+++ b/lib/getStaticTypes.js
@@ -20,7 +20,7 @@ module.exports = async playroomConfig => {
     typeScriptFiles = ['**/*.{ts,tsx}', '!**/node_modules']
   } = playroomConfig;
 
-  const tsConfigPath = await findUp('tsconfig.json', { cwd });
+  const tsConfigPath = await findUp('tsconfig.json', { cwd, absolute: true });
 
   if (!tsConfigPath) {
     return {};


### PR DESCRIPTION
Currently, types aren't captured for this config:

```
const playroomConfig = {
  cwd: path.resolve('../my-design-system'),
};
```

This architecture being common in a monorepo, this little change does the trick.