### PR TITLE
fix: Ensure frames are interactive

### DIFF
--- a/src/Playroom/Preview/Preview.less
+++ b/src/Playroom/Preview/Preview.less
@@ -19,6 +19,7 @@
   background-color: @white;
 
   &:before {
+    pointer-events: none;
     content: '';
     position: absolute;
     top: 0;


### PR DESCRIPTION
The `:before` pseudo element that provides an animated box shadow around each frame is currently swallowing clicks on the frame content, so this PR adds `pointer-events: none` to ensure that clicks go through correctly.