### PR TITLE
fix: Align ToolbarItem content to center

### DIFF
--- a/src/Playroom/ToolbarItem/ToolbarItem.less
+++ b/src/Playroom/ToolbarItem/ToolbarItem.less
@@ -18,6 +18,7 @@
   appearance: none;
   outline: none;
   display: flex;
+  align-items: center;
   justify-content: center;
   color: currentColor;
   cursor: pointer;


### PR DESCRIPTION
The ToolbarItem content is broken on Firefox.

**Before:**
![Screenshot from 2019-12-20 14-17-56](https://user-images.githubusercontent.com/2369851/71277715-6c45b280-2334-11ea-9ef4-8d1c5c7b5d4e.png)

**After:**
![Screenshot from 2019-12-20 14-17-27](https://user-images.githubusercontent.com/2369851/71277727-710a6680-2334-11ea-9ccd-1317598024ef.png)