### PR TITLE
fix: Align frames to centre

### DIFF
--- a/src/Playroom/Preview/Preview.less
+++ b/src/Playroom/Preview/Preview.less
@@ -9,10 +9,12 @@
   overflow-y: hidden;
   white-space: nowrap;
   padding: @preview-padding 0;
+  text-align: center;
 }
 
 .frameContainer {
   display: inline-block;
+  text-align: left;
   position: relative;
   height: 97%;
   margin-right: @preview-padding;


### PR DESCRIPTION
This ensures that frames are horizontally centred when the total width of all frames is lower than the outer viewport width. When the frames can no longer fit on the screen, the layout is exactly the same as today, seemingly left-aligned with a horizontal scrollbar.

Before:

<img width="938" alt="Screen Shot 2019-12-24 at 9 47 30 am" src="https://user-images.githubusercontent.com/696693/71383882-86340d80-2632-11ea-827c-7647d3670bd3.png">

After:

<img width="938" alt="Screen Shot 2019-12-24 at 9 47 50 am" src="https://user-images.githubusercontent.com/696693/71383889-8f24df00-2632-11ea-8104-0b41ebcc0293.png">

This improvement is especially noticeable when the code pane is docked to the right:

<img width="1455" alt="Screen Shot 2019-12-24 at 9 48 08 am" src="https://user-images.githubusercontent.com/696693/71383918-a5329f80-2632-11ea-8739-d181b39fb3a7.png">
