### PR TITLE
ci: Run validate action on forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    name: Publish & Deploy
+    name: Publish to npm
     runs-on: ubuntu-latest
     env:
       CI: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,6 @@
 name: Validate
 
-on: push
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
A couple of tweaks to the actions setup:
- Tweak Release step name, as it's not deploying a site, only publishing to npm
- Run Validate on pull_request event to run in this repo context for forks/PRs
- Make PreviewSite not a required action.