### PR TITLE
fix: Cannot read property ‘slice’ of undefined error

### DIFF
--- a/src/Playroom/CodeEditor/CodeEditor.tsx
+++ b/src/Playroom/CodeEditor/CodeEditor.tsx
@@ -237,7 +237,7 @@ export const CodeEditor = ({ code, onChange, previewCode, hints }: Props) => {
 
             dispatch({
               type: 'updateCursorPosition',
-              payload: { position: { line, ch } }
+              payload: { position: { line, ch }, code: editor.getValue() }
             });
           }
         });

--- a/src/StoreContext/StoreContext.tsx
+++ b/src/StoreContext/StoreContext.tsx
@@ -67,7 +67,7 @@ type Action =
   | { type: 'updateCode'; payload: { code: string; cursor?: CursorPosition } }
   | {
       type: 'updateCursorPosition';
-      payload: { position: CursorPosition };
+      payload: { position: CursorPosition; code?: string };
     }
   | { type: 'persistSnippet'; payload: { snippet: Snippet } }
   | { type: 'previewSnippet'; payload: { snippet: Snippet | null } }
@@ -168,14 +168,16 @@ const createReducer = ({
     }
 
     case 'updateCursorPosition': {
-      const { position } = action.payload;
+      const { position, code } = action.payload;
+      const newCode = code && code !== state.code ? code : state.code;
 
       return {
         ...state,
+        code: newCode,
         cursorPosition: position,
         statusMessage: undefined,
         validCursorPosition: isValidLocation({
-          code: state.code,
+          code: newCode,
           cursor: position
         })
       };


### PR DESCRIPTION
With the editor now checking the validity of the cursor position on every cursor activity, there is a race condition where the store has a mismatched combination of code and cursor.

Now when the editor notifies of a cursor change, it sends the current code with the payload to ensure the validity check always has all the information required.

Fixes https://github.com/seek-oss/playroom/issues/151