### PR TITLE
feat: Show hints on Ctrl+Space

### DIFF
--- a/src/Playroom/CodeEditor/CodeEditor.tsx
+++ b/src/Playroom/CodeEditor/CodeEditor.tsx
@@ -262,6 +262,7 @@ export const CodeEditor = ({ code, onChange, previewCode, hints }: Props) => {
               cm.replaceSelection(spaces);
             }
           },
+          'Ctrl-Space': completeIfInTag,
           "'<'": completeAfter,
           "'/'": completeIfAfterLt,
           "' '": completeIfInTag,


### PR DESCRIPTION
Been using Playroom for a few weeks now and from what I can tell there is no way to get hints, other than pressing space, when you split the props by line.

```jsx
<Button
    type="button"
    // Right here I have to insert a space to get hints which I then have to remove
/>
```

With this very little change you can simply press `Ctrl+Space` which is what you're probably used to if you use any IDE.

The hints addon is quite good and does what you expect when you trigger the hints on "unsuspected" places. In other words, this does not seem to break anything or add unwanted behaviour.

Also want to thank you guys for this piece of software, great work you're doing. Hope I can contribute more than this in the future 🙏