### PR TITLE
feat: Add iframeSandbox config

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ module.exports = {
   webpackConfig: () => ({
     // Custom webpack config goes here...
   }),
-  iframeSandbox: true,
+  iframeSandbox: 'allow-scripts',
 };
 ```
 
@@ -80,7 +80,7 @@ export { Button } from '../Button'; // Re-exporting a named export
 // etc...
 ```
 
-The `iframeSandbox` option can be used to control the `sandbox` attribute on Playroom's iframe. A value of `true` will set `sandbox="allow-scripts"` or a custom string value can be used.
+The `iframeSandbox` option can be used to set the [`sandbox` attribute](https://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/) on Playroom's iframe. A minimum of `allow-scripts` is required for Playroom to work.
 
 Now that your project is configured, you can start a local development server:
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ module.exports = {
   webpackConfig: () => ({
     // Custom webpack config goes here...
   }),
+  iframeSandbox: true,
 };
 ```
 
@@ -78,6 +79,8 @@ export { default as Text } from '../Text'; // Re-exporting a default export
 export { Button } from '../Button'; // Re-exporting a named export
 // etc...
 ```
+
+The `iframeSandbox` option can be used to control the `sandbox` attribute on Playroom's iframe. A value of `true` will set `sandbox="allow-scripts"` or a custom string value can be used.
 
 Now that your project is configured, you can start a local development server:
 

--- a/cypress/projects/basic/playroom.config.js
+++ b/cypress/projects/basic/playroom.config.js
@@ -3,4 +3,5 @@ module.exports = {
   snippets: './snippets',
   outputPath: './dist',
   openBrowser: false,
+  iframeSandbox: true,
 };

--- a/cypress/projects/basic/playroom.config.js
+++ b/cypress/projects/basic/playroom.config.js
@@ -3,5 +3,4 @@ module.exports = {
   snippets: './snippets',
   outputPath: './dist',
   openBrowser: false,
-  iframeSandbox: true,
 };

--- a/examples/seek-style-guide/playroom.config.js
+++ b/examples/seek-style-guide/playroom.config.js
@@ -47,5 +47,5 @@ module.exports = {
         ],
       },
     }),
-  iframeSandbox: true,
+  iframeSandbox: 'allow-scripts',
 };

--- a/examples/seek-style-guide/playroom.config.js
+++ b/examples/seek-style-guide/playroom.config.js
@@ -47,4 +47,5 @@ module.exports = {
         ],
       },
     }),
+  iframeSandbox: true,
 };

--- a/lib/start.js
+++ b/lib/start.js
@@ -19,7 +19,7 @@ module.exports = async (config, callback) => {
     watchOptions: { ignored: /node_modules/ },
     // Added to prevent Webpack HMR from breaking when iframeSandbox option is used
     // See: https://github.com/webpack/webpack-dev-server/issues/1604
-    disableHostCheck: true
+    disableHostCheck: true,
   };
 
   const compiler = webpack(webpackConfig);

--- a/lib/start.js
+++ b/lib/start.js
@@ -17,6 +17,9 @@ module.exports = async (config, callback) => {
     compress: true,
     inline: true,
     watchOptions: { ignored: /node_modules/ },
+    // Added to prevent console errors via Webpack local development when sandbox mode is enabled
+    // See: https://github.com/webpack/webpack-dev-server/issues/1604
+    disableHostCheck: true
   };
 
   const compiler = webpack(webpackConfig);

--- a/lib/start.js
+++ b/lib/start.js
@@ -17,7 +17,7 @@ module.exports = async (config, callback) => {
     compress: true,
     inline: true,
     watchOptions: { ignored: /node_modules/ },
-    // Added to prevent console errors via Webpack local development when sandbox mode is enabled
+    // Added to prevent Webpack HMR from breaking when iframeSandbox option is used
     // See: https://github.com/webpack/webpack-dev-server/issues/1604
     disableHostCheck: true
   };

--- a/src/Playroom/Frames/Iframe.tsx
+++ b/src/Playroom/Frames/Iframe.tsx
@@ -15,11 +15,11 @@ interface IframeProps extends AllHTMLAttributes<HTMLIFrameElement> {
 const playroomConfig = (window.__playroomConfig__ = __PLAYROOM_GLOBAL__CONFIG__);
 
 export default function Iframe({
-                                 intersectionRootRef,
-                                 style,
-                                 src,
-                                 ...restProps
-                               }: IframeProps) {
+  intersectionRootRef,
+  style,
+  src,
+  ...restProps
+}: IframeProps) {
   const [loaded, setLoaded] = useState(false);
   const [renderedSrc, setRenderedSrc] = useState<string | null>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);

--- a/src/Playroom/Frames/Iframe.tsx
+++ b/src/Playroom/Frames/Iframe.tsx
@@ -14,16 +14,6 @@ interface IframeProps extends AllHTMLAttributes<HTMLIFrameElement> {
 
 const playroomConfig = (window.__playroomConfig__ = __PLAYROOM_GLOBAL__CONFIG__);
 
-const getIframeSandboxAttribute = (
-  iframeSandboxConfig: string | boolean | undefined
-): string | undefined => {
-  if (iframeSandboxConfig === true) {
-    return 'allow-scripts';
-  } else if (typeof iframeSandboxConfig === 'string') {
-    return iframeSandboxConfig;
-  }
-};
-
 export default function Iframe({
   intersectionRootRef,
   style,
@@ -64,7 +54,7 @@ export default function Iframe({
   return (
     <iframe
       ref={iframeRef}
-      sandbox={getIframeSandboxAttribute(playroomConfig.iframeSandbox)}
+      sandbox={playroomConfig.iframeSandbox}
       onLoad={() => setLoaded(true)}
       onMouseEnter={() => {
         if (src !== renderedSrc) {

--- a/src/Playroom/Frames/Iframe.tsx
+++ b/src/Playroom/Frames/Iframe.tsx
@@ -12,12 +12,14 @@ interface IframeProps extends AllHTMLAttributes<HTMLIFrameElement> {
   intersectionRootRef: MutableRefObject<Element | null>;
 }
 
+const playroomConfig = (window.__playroomConfig__ = __PLAYROOM_GLOBAL__CONFIG__);
+
 export default function Iframe({
-  intersectionRootRef,
-  style,
-  src,
-  ...restProps
-}: IframeProps) {
+                                 intersectionRootRef,
+                                 style,
+                                 src,
+                                 ...restProps
+                               }: IframeProps) {
   const [loaded, setLoaded] = useState(false);
   const [renderedSrc, setRenderedSrc] = useState<string | null>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -52,6 +54,7 @@ export default function Iframe({
   return (
     <iframe
       ref={iframeRef}
+      sandbox={playroomConfig.iframeSandbox ?? "allow-scripts"}
       onLoad={() => setLoaded(true)}
       onMouseEnter={() => {
         if (src !== renderedSrc) {

--- a/src/Playroom/Frames/Iframe.tsx
+++ b/src/Playroom/Frames/Iframe.tsx
@@ -14,6 +14,14 @@ interface IframeProps extends AllHTMLAttributes<HTMLIFrameElement> {
 
 const playroomConfig = (window.__playroomConfig__ = __PLAYROOM_GLOBAL__CONFIG__);
 
+const getIframeSandboxAttribute = (iframeSandboxConfig) => {
+  if (iframeSandboxConfig === true) {
+    return 'allow-scripts';
+  } else if (typeof iframeSandboxConfig === 'string') {
+    return iframeSandboxConfig;
+  }
+};
+
 export default function Iframe({
   intersectionRootRef,
   style,
@@ -54,7 +62,7 @@ export default function Iframe({
   return (
     <iframe
       ref={iframeRef}
-      sandbox={playroomConfig.iframeSandbox ?? "allow-scripts"}
+      sandbox={getIframeSandboxAttribute(playroomConfig.iframeSandbox)}
       onLoad={() => setLoaded(true)}
       onMouseEnter={() => {
         if (src !== renderedSrc) {

--- a/src/Playroom/Frames/Iframe.tsx
+++ b/src/Playroom/Frames/Iframe.tsx
@@ -14,7 +14,9 @@ interface IframeProps extends AllHTMLAttributes<HTMLIFrameElement> {
 
 const playroomConfig = (window.__playroomConfig__ = __PLAYROOM_GLOBAL__CONFIG__);
 
-const getIframeSandboxAttribute = (iframeSandboxConfig) => {
+const getIframeSandboxAttribute = (
+  iframeSandboxConfig: string | boolean | undefined
+): string | undefined => {
   if (iframeSandboxConfig === true) {
     return 'allow-scripts';
   } else if (typeof iframeSandboxConfig === 'string') {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,7 +11,7 @@ interface PlayroomConfig {
   storageKey?: string;
   webpackConfig?: () => void;
   baseUrl?: string;
-  iframeSandbox?: string | boolean;
+  iframeSandbox?: string;
 }
 
 interface InternalPlayroomConfig extends PlayroomConfig {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,6 +11,7 @@ interface PlayroomConfig {
   storageKey?: string;
   webpackConfig?: () => void;
   baseUrl?: string;
+  iframeSandbox?: string | boolean;
 }
 
 interface InternalPlayroomConfig extends PlayroomConfig {


### PR DESCRIPTION
Hi! We’re looking at integrating Playroom on our design system style guide at [NerdWallet](https://www.nerdwallet.com/). Given Playroom’s inherent ability to execute arbitrary code, one of our security engineers had some recommendations:

1. Move the site to its own domain where cookies for other NerdWallet applications will not be available
1. Use the `sandbox` attribute in Playroom’s iframe to sandbox arbitrary code execution

This PR is about the second item and implements the `sandbox` attribute in the `<Iframe>` component driven by `playroom.config.js` config. Credit for the implementation also goes to @mhensley-nw.

This security concern was also raised in #125.

### Unbreaking Webpack HMR

Like #125 mentions, using `sandbox=”allow-scripts”` breaks Webpack hot module replacement in development. This is because Webpack expects an `Origin` header and `sandbox` makes requests omit `Origin`. This is fixed by using webpack-dev-server’s `disableHostCheck` option, which makes Webpack not expect the `Origin` header. More information in this Webpack issue: https://github.com/webpack/webpack-dev-server/issues/1604.

### Configuration

This is an opt-in feature using the `iframeSandbox` key in `playroom.config.js`. A value of `true` defaults to `”allow-scripts”` or a custom string can be used. We think `”allow-scripts”` might be a sane default, so you may consider making that the default in the future.
