### PR TITLE
fix: Add theme to compressParams

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -12,6 +12,7 @@ interface CompressParamsOptions {
   code?: string;
   themes?: string[];
   widths?: number[];
+  theme?: string;
 }
 export const compressParams: (options: CompressParamsOptions) => string;
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,10 +1,11 @@
 const lzString = require('lz-string');
 
-const compressParams = ({ code, themes, widths }) => {
+const compressParams = ({ code, themes, widths, theme }) => {
   const data = JSON.stringify({
     ...(code ? { code } : {}),
     ...(themes ? { themes } : {}),
     ...(widths ? { widths } : {}),
+    ...(theme ? { theme } : {}),
   });
 
   return lzString.compressToEncodedURIComponent(data);


### PR DESCRIPTION
Add theme to compressParams so PreviewUrl works with multibranding.