### PR TITLE
feat: Define Components at beginning and end of body

### DIFF
--- a/lib/defaultModules/bodyEnd.js
+++ b/lib/defaultModules/bodyEnd.js
@@ -1,0 +1,1 @@
+export default () => null;

--- a/lib/defaultModules/bodyStart.js
+++ b/lib/defaultModules/bodyStart.js
@@ -1,0 +1,1 @@
+export default () => null;

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -52,6 +52,12 @@ module.exports = async (playroomConfig, options) => {
         __PLAYROOM_ALIAS__FRAME_COMPONENT__: playroomConfig.frameComponent
           ? relativeResolve(playroomConfig.frameComponent)
           : require.resolve('./defaultModules/FrameComponent'),
+        __PLAYROOM_ALIAS__BODY_START__: playroomConfig.bodyStart
+          ? relativeResolve(playroomConfig.bodyStart)
+          : require.resolve('./defaultModules/bodyStart'),
+        __PLAYROOM_ALIAS__BODY_END__: playroomConfig.bodyEnd
+          ? relativeResolve(playroomConfig.bodyEnd)
+          : require.resolve('./defaultModules/bodyEnd'),
       },
     },
     module: {

--- a/src/Playroom/Playroom.tsx
+++ b/src/Playroom/Playroom.tsx
@@ -71,9 +71,18 @@ export interface PlayroomProps {
   themes: string[];
   widths: number[];
   snippets: Snippets;
+  bodyStart: React.ComponentClass;
+  bodyEnd: React.ComponentClass;
 }
 
-export default ({ components, themes, widths, snippets }: PlayroomProps) => {
+export default ({
+  components,
+  themes,
+  widths,
+  snippets,
+  bodyStart: BodyStart,
+  bodyEnd: BodyEnd,
+}: PlayroomProps) => {
   const [
     {
       editorPosition,
@@ -174,48 +183,54 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
     );
 
   return (
-    <div className={styles.root}>
-      <div
-        className={styles.previewContainer}
-        style={
-          editorHidden
-            ? undefined
-            : {
-                right: { right: editorWidth },
-                bottom: { bottom: editorHeight },
-                undocked: undefined,
-              }[editorPosition]
-        }
-      >
-        <Frames
-          code={previewRenderCode || code}
-          themes={
-            visibleThemes && visibleThemes.length > 0 ? visibleThemes : themes
-          }
-          widths={
-            visibleWidths && visibleWidths.length > 0 ? visibleWidths : widths
-          }
-        />
+    <>
+      <BodyStart />
+
+      <div className={styles.root}>
         <div
-          className={classnames(styles.toggleEditorContainer, {
-            [styles.isBottom]: isHorizontalEditor,
-          })}
+          className={styles.previewContainer}
+          style={
+            editorHidden
+              ? undefined
+              : {
+                  right: { right: editorWidth },
+                  bottom: { bottom: editorHeight },
+                  undocked: undefined,
+                }[editorPosition]
+          }
         >
-          <button
-            className={styles.toggleEditorButton}
-            title={`${editorHidden ? 'Show' : 'Hide'} the editor`}
-            onClick={() =>
-              dispatch({ type: editorHidden ? 'showEditor' : 'hideEditor' })
+          <Frames
+            code={previewRenderCode || code}
+            themes={
+              visibleThemes && visibleThemes.length > 0 ? visibleThemes : themes
             }
+            widths={
+              visibleWidths && visibleWidths.length > 0 ? visibleWidths : widths
+            }
+          />
+          <div
+            className={classnames(styles.toggleEditorContainer, {
+              [styles.isBottom]: isHorizontalEditor,
+            })}
           >
-            <ChevronIcon
-              size={16}
-              direction={resolveDirection(editorPosition, editorHidden)}
-            />
-          </button>
+            <button
+              className={styles.toggleEditorButton}
+              title={`${editorHidden ? 'Show' : 'Hide'} the editor`}
+              onClick={() =>
+                dispatch({ type: editorHidden ? 'showEditor' : 'hideEditor' })
+              }
+            >
+              <ChevronIcon
+                size={16}
+                direction={resolveDirection(editorPosition, editorHidden)}
+              />
+            </button>
+          </div>
         </div>
+        {editorContainer}
       </div>
-      {editorContainer}
-    </div>
+
+      <BodyEnd />
+    </>
   );
 };

--- a/src/bodyEnd.js
+++ b/src/bodyEnd.js
@@ -1,0 +1,4 @@
+/* eslint-disable-next-line import/no-unresolved */
+const bodyEnd = require('__PLAYROOM_ALIAS__BODY_END__');
+
+module.exports = bodyEnd.default || bodyEnd;

--- a/src/bodyStart.js
+++ b/src/bodyStart.js
@@ -1,0 +1,4 @@
+/* eslint-disable-next-line import/no-unresolved */
+const bodyStart = require('__PLAYROOM_ALIAS__BODY_START__');
+
+module.exports = bodyStart.default || bodyStart;

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,8 @@ polyfillIntersectionObserver().then(() => {
     themes = require('./themes'),
     components = require('./components'),
     snippets = require('./snippets'),
+    bodyStart = require('./bodyStart'),
+    bodyEnd = require('./bodyEnd'),
   } = {}) => {
     const themeNames = Object.keys(themes);
 
@@ -29,6 +31,8 @@ polyfillIntersectionObserver().then(() => {
           components={components}
           widths={widths}
           themes={themeNames}
+          bodyStart={bodyStart}
+          bodyEnd={bodyEnd}
           snippets={
             typeof snippets.default !== 'undefined'
               ? snippets.default
@@ -52,6 +56,14 @@ polyfillIntersectionObserver().then(() => {
 
     module.hot.accept('./snippets', () => {
       renderPlayroom({ snippets: require('./snippets') });
+    });
+
+    module.hot.accept('./bodyStart', () => {
+      renderPlayroom({ bodyStart: require('./bodyStart') });
+    });
+
+    module.hot.accept('./bodyEnd', () => {
+      renderPlayroom({ bodyEnd: require('./bodyEnd') });
     });
   }
 });


### PR DESCRIPTION
Adds 2 options to `playroom.config.js`, which are `bodyStart` and `bodyEnd`. They work similarly to `frameComponent`, which means that they receive a file path to a component which will be rendered at the beginning/end of body (well in fact in the root div).

Example usage:
```tsx
// playroom.config.js
{
  // ...
  bodyEnd: './bodyEnd.js'
  // ...
}

// bodyEnd.js
import React from 'react'

export default () => (
  <script type="text/javascript">
    {/* Put Analytics script here */}
  </script>
)
```

This was necessary for my team as we wanted to plug an Analytics library on our playroom, which of course requires us to add a script in the `<body />`. It could also be used to provide a watermark, link or anything absolutely positioned on the page, maybe for branding purposes. Furthermore, I think this could also fix issue #40, as using the new `bodyStart` option and a library such as [React Helmet](https://github.com/nfl/react-helmet), this use case could be covered.

I am also aware that some things are missing from this PR such as examples and documentation, which I will include once I know this is relevant to this repo. 

Also, I am considering adding a similar feature to the preview page, so we can have analytics there too. Prop names could be something like `previewBodyStart` and `previewBodyEnd`.