### PR TITLE
Correctly display widths specified in non-px units

### DIFF
--- a/src/Playroom/Frames/Frames.tsx
+++ b/src/Playroom/Frames/Frames.tsx
@@ -21,7 +21,11 @@ export default function Frames({ code, themes, widths }: FramesProps) {
   const scrollingPanelRef = useRef<HTMLDivElement | null>(null);
 
   const frames = flatMap(widths, (width) =>
-    themes.map((theme) => ({ theme, width }))
+    themes.map((theme) => ({
+      theme,
+      width,
+      widthName: `${width}${/\d$/.test(width.toString()) ? 'px' : ''}`,
+    }))
   );
 
   let renderCode = code;
@@ -54,14 +58,11 @@ export default function Frames({ code, themes, widths }: FramesProps) {
           </div>
           <div className={styles.frameName} data-testid="frameName">
             {frame.theme === '__PLAYROOM__NO_THEME__' ? (
-              <Text weight="strong">
-                {frame.width}
-                px
-              </Text>
+              <Text weight="strong">{frame.widthName}</Text>
             ) : (
               <Text>
                 <Strong>{frame.theme}</Strong>
-                {` \u2013 ${frame.width}px`}
+                {` \u2013 ${frame.widthName}`}
               </Text>
             )}
           </div>


### PR DESCRIPTION
Specifying a width with any unit other than `px` results in the following:

<img width="71" alt="Screen Shot 2020-09-14 at 1 22 13 pm" src="https://user-images.githubusercontent.com/612020/93040436-5c71b980-f68d-11ea-9731-24173733708f.png">

ie; it always appends `px`.

This change uses the assumption that when the width value ends in a number, it is an implicit `px` value, otherwise, it leaves it alone and uses the exact value supplied for display.