### PR TITLE
feat: Supply HTML Template for Playroom & Preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ module.exports = {
   widths: [320, 375, 768, 1024],
   port: 9000,
   openBrowser: true,
+  htmlTemplate: './template.ejs',
   paramType: 'search', // default is 'hash'
   exampleCode: `
     <Button>
@@ -72,6 +73,8 @@ module.exports = {
 ```
 
 _Note: `port` and `openBrowser` options will be set to `9000` and `true` (respectively) by default whenever they are omitted from the config above._
+
+_Note 2: `htmlTemplate` will be loaded by [HtmlWebpackPlugin](https://github.com/jantimon/html-webpack-plugin). For advanced templating options, see their [documentation](https://github.com/jantimon/html-webpack-plugin/blob/master/docs/template-option.md) on this option (named `template` and not `htmlTemplate` like Playroom) or the [default template](https://github.com/jantimon/html-webpack-plugin/blob/master/default_index.ejs) used. Insert an element with ID `root` in your HTML and Playroom will be rendered in it._
 
 Your `components` file is expected to export a single object or a series of named exports. For example:
 

--- a/cypress/projects/themed/playroom.config.js
+++ b/cypress/projects/themed/playroom.config.js
@@ -7,4 +7,5 @@ module.exports = {
   paramType: 'search',
   port: 9001,
   storageKey: 'playroom-example-themed',
+  htmlTemplate: './template.ejs',
 };

--- a/cypress/projects/themed/playroom.config.js
+++ b/cypress/projects/themed/playroom.config.js
@@ -8,4 +8,5 @@ module.exports = {
   port: 9001,
   storageKey: 'playroom-example-themed',
   htmlTemplate: './template.ejs',
+  previewHtmlTemplate: './preview-template.ejs',
 };

--- a/cypress/projects/themed/preview-template.ejs
+++ b/cypress/projects/themed/preview-template.ejs
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title><%= htmlWebpackPlugin.options.title %></title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/javascript">
+      console.info('Dummy code appended after Playroom Preview...');
+    </script>
+  </body>
+</html>

--- a/cypress/projects/themed/template.ejs
+++ b/cypress/projects/themed/template.ejs
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title><%= htmlWebpackPlugin.options.title %></title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/javascript">
+      console.info('Dummy code appended after Playroom...');
+    </script>
+  </body>
+</html>

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -147,6 +147,10 @@ module.exports = async (playroomConfig, options) => {
         chunks: ['index'],
         filename: 'index.html',
         base: playroomConfig.baseUrl,
+        // Spread the template option, since setting it to null, undefined or "" if none is specified causes an issue.
+        ...(playroomConfig.htmlTemplate
+          ? { template: relativeResolve(playroomConfig.htmlTemplate) }
+          : {}),
       }),
       new HtmlWebpackPlugin({
         title: 'Playroom Frame',

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -163,6 +163,10 @@ module.exports = async (playroomConfig, options) => {
         chunksSortMode: 'none',
         chunks: ['preview'],
         filename: 'preview/index.html',
+        // Spread the template option, since setting it to null, undefined or "" if none is specified causes an issue.
+        ...(playroomConfig.previewHtmlTemplate
+          ? { template: relativeResolve(playroomConfig.previewHtmlTemplate) }
+          : {}),
       }),
       ...(options.production
         ? []

--- a/src/get-or-create-root.js
+++ b/src/get-or-create-root.js
@@ -1,0 +1,26 @@
+/**
+ * Get or create the root where we want to render Playroom.
+ * - If `configPath` is set, use an element with ID "root" as the root.
+ * - If no template is provided, simply create a `<div />` element and return it.
+ *
+ * @param configPath Path to the HTML template
+ */
+module.exports = (configPath) => {
+  if (configPath) {
+    const root = document.getElementById('root');
+
+    if (!root) {
+      // If #root element is not found, throw error as we won't be able to render Playroom.
+      throw new Error(
+        'No element found in body with ID "root". Playroom won\'t be rendered. Put a `<div id="root"></div>` in your HTML template where you want to render Playroom.'
+      );
+    }
+
+    return root;
+  }
+
+  const outlet = document.createElement('div');
+  document.body.appendChild(outlet);
+
+  return outlet;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import { render } from 'react-dom';
 
 import Playroom from './Playroom/Playroom';
 import { StoreProvider } from './StoreContext/StoreContext';
+import getOrCreateRoot from './get-or-create-root';
 import playroomConfig from './config';
 
 const polyfillIntersectionObserver = () =>
@@ -10,34 +11,9 @@ const polyfillIntersectionObserver = () =>
     ? Promise.resolve()
     : import('intersection-observer');
 
-/**
- * Get the root where we want to render Playroom.
- * - If an `htmlTemplate` option is provided, use an element with ID "root" as the root.
- * - If no template is provided, simply create a `<div />` element and return it.
- */
-const getOrCreateRoot = () => {
-  if (playroomConfig.htmlTemplate) {
-    const root = document.getElementById('root');
-
-    if (!root) {
-      // If #root element is not found, throw error as we won't be able to render Playroom.
-      throw new Error(
-        'No element found in body with ID "root". Playroom won\'t be rendered. Put a `<div id="root"></div>` in your HTML template where you want to render Playroom.'
-      );
-    }
-
-    return root;
-  }
-
-  const outlet = document.createElement('div');
-  document.body.appendChild(outlet);
-
-  return outlet;
-};
-
 polyfillIntersectionObserver().then(() => {
   const widths = playroomConfig.widths || [320, 375, 768, 1024];
-  const root = getOrCreateRoot();
+  const root = getOrCreateRoot(playroomConfig.htmlTemplate);
 
   const renderPlayroom = ({
     themes = require('./themes'),

--- a/src/index.js
+++ b/src/index.js
@@ -10,11 +10,34 @@ const polyfillIntersectionObserver = () =>
     ? Promise.resolve()
     : import('intersection-observer');
 
-polyfillIntersectionObserver().then(() => {
-  const widths = playroomConfig.widths || [320, 375, 768, 1024];
+/**
+ * Get the root where we want to render Playroom.
+ * - If an `htmlTemplate` option is provided, use an element with ID "root" as the root.
+ * - If no template is provided, simply create a `<div />` element and return it.
+ */
+const getOrCreateRoot = () => {
+  if (playroomConfig.htmlTemplate) {
+    const root = document.getElementById('root');
+
+    if (!root) {
+      // If #root element is not found, throw error as we won't be able to render Playroom.
+      throw new Error(
+        'No element found in body with ID "root". Playroom won\'t be rendered. Put a `<div id="root"></div>` in your HTML template where you want to render Playroom.'
+      );
+    }
+
+    return root;
+  }
 
   const outlet = document.createElement('div');
   document.body.appendChild(outlet);
+
+  return outlet;
+};
+
+polyfillIntersectionObserver().then(() => {
+  const widths = playroomConfig.widths || [320, 375, 768, 1024];
+  const root = getOrCreateRoot();
 
   const renderPlayroom = ({
     themes = require('./themes'),
@@ -36,7 +59,7 @@ polyfillIntersectionObserver().then(() => {
           }
         />
       </StoreProvider>,
-      outlet
+      root
     );
   };
   renderPlayroom();

--- a/src/preview.js
+++ b/src/preview.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { render } from 'react-dom';
 import Preview from './Playroom/Preview';
+import playroomConfig from './config';
+import getOrCreateRoot from './get-or-create-root';
 
-const outlet = document.createElement('div');
-document.body.appendChild(outlet);
+const root = getOrCreateRoot(playroomConfig.previewHtmlTemplate);
 
 const renderPreview = ({
   themes = require('./themes'),
@@ -16,7 +17,7 @@ const renderPreview = ({
       themes={themes}
       FrameComponent={FrameComponent}
     />,
-    outlet
+    root
   );
 };
 renderPreview();


### PR DESCRIPTION
Adds new `htmlTemplate` and `previewHtmlTemplate` options in config, which receive a path to the HTML template used to render Playroom (and Preview).

Sample usage: 
```js
{
  // ...
  htmlTemplate: './template.html',
  previewHtmlTemplate: './preview-template.html',
  // ...
}
```

If no template is provided, Playroom renders exactly as it did before this change.

_Note: Template gets loaded by HtmlWebpackPlugin as mentioned in Readme. This way, we can leverage all the power of loaders or simply supply a simple `.html` file._

I also extended `themed` example with the new options, for example usage.

This will also fix issue #40.