### PR TITLE
fix(Preview): Don't set negative z-index for preview content

### DIFF
--- a/src/Playroom/Preview.less
+++ b/src/Playroom/Preview.less
@@ -1,4 +1,3 @@
 .container {
   position: relative;
-  z-index: -1;
 }


### PR DESCRIPTION
fixes change made in #187

rather than just reporting, this should fix issue #197

simply setting `position: relative;` on the container of the preview content will prevent child elements within the container to stack above the `SplashScreen` because they will be stacked relatively to the container (and not it's parent)