### PR TITLE
fix: Ensure rendered content is interactive in preview mode

### DIFF
--- a/src/Playroom/Preview.less
+++ b/src/Playroom/Preview.less
@@ -1,4 +1,9 @@
-.container {
+.renderContainer {
   position: relative;
-  z-index: -1;
+  z-index: 0;
+}
+
+.splashScreenContainer {
+  position: relative;
+  z-index: 1;
 }

--- a/src/Playroom/Preview.tsx
+++ b/src/Playroom/Preview.tsx
@@ -50,10 +50,12 @@ export default ({ themes, components, FrameComponent }: PreviewProps) => {
         themeName={themeName || '__PLAYROOM__NO_THEME__'}
         theme={resolvedTheme}
       >
-        <div className={styles.container}>
+        <div className={styles.renderContainer}>
           <RenderCode code={code} scope={components} />
         </div>
-        <SplashScreen />
+        <div className={styles.splashScreenContainer}>
+          <SplashScreen />
+        </div>
       </FrameComponent>
     </CatchErrors>
   );


### PR DESCRIPTION
This PR creates two separate stacking contexts for the rendered content and the splash screen, ensuring that the splash screen is always above the rendered content (even if it contains elements with very high z-indexes), but also ensuring that the rendered content is still interactive.

Closes #198 
Fixes #197 