### PR TITLE
Docs to show all prop values with noErrorTruncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ module.exports = {
 };
 ```
 
+### Missing autocomplete options
+
+In some cases, when there are a large number of possible values for a prop, not all options will appear within Playroom's autocomplete popup. This is caused [by an unintended behaviour in TypeScript's compiler](https://github.com/Microsoft/TypeScript/issues/26238).
+
+To force TypeScript to show all possible values for a prop, you can provide a `noErrorTruncation: true` option in `tsconfig.json`.
+
+```json
+{
+  "compilerOptions": {
+    ...
+    "noErrorTruncation": true
+  },
+}
+```
+
+_NOTE: This may cause longer than usual error messages from the TypeScript compiler when the same `tsconfig.json` is used outside of Playroom._
+
 ## Storybook Integration
 
 If you are interested in integrating Playroom into Storybook, check out [storybook-addon-playroom](https://github.com/rbardini/storybook-addon-playroom).


### PR DESCRIPTION
This was an interesting one!

`react-docgen-typescript` calls TypeScript which returns a comma delimited string of strings representing the possible types. This string was passed back to Playroom, which then used a regex to snip out anything that wasn't explicitly a match for essentially `"(.*)"`.

The end result was TypeScript would return strings like:

```js
{
    "name": "\"transparent\" | \"current\" | \"black\" | \"white\" | \"whiteAlpha\" | \"blackAlpha\" | \"gray\" | \"red\" |
  \"orange\" | \"yellow\" | \"green\" | \"teal\" | \"blue\" | \"cyan\" | \"purple\" | \"pink\" | \"linkedin\" | ... 5 more ... | und
  efined"
}
```

_(Note the `... 5 more ...`)_

And Playroom would end up with an array of:

```json
[
  "transparent",
  "current",
  "black",
  "white",
  "whiteAlpha",
  "blackAlpha",
  "gray",
  "red",
  "orange",
  "yellow",
  "green",
  "teal",
  "blue",
  "cyan",
  "purple",
  "pink",
  "linkedin",
]
```

But when using `noErrorTruncation`, Typescript will return the full set of types:

```js
{
  "name": "\"transparent\" | \"current\" | \"black\" | \"white\" | \"whiteAlpha\" | \"blackAlpha\" | \"gray\" | \"red\" |
\"orange\" | \"yellow\" | \"green\" | \"teal\" | \"blue\" | \"cyan\" | \"purple\" | \"pink\" | \"linkedin\" | \"facebook\" | \"mes
senger\" | \"whatsapp\" | \"twitter\" | \"telegram\" | undefined"
}
```

So Playroom gets the full array of possible values:

```json
[
  "transparent",
  "current",
  "black",
  "white",
  "whiteAlpha",
  "blackAlpha",
  "gray",
  "red",
  "orange",
  "yellow",
  "green",
  "teal",
  "blue",
  "cyan",
  "purple",
  "pink",
  "linkedin",
  "facebook",
  "mes senger",
  "whatsapp",
  "twitter",
  "telegram",
]
```

The way TypeScript returns a comma delimited string of strings representing the possible types was very surprising! Why doesn't TypeScript return something more... _structured_?

---

This issue is particularly noticable in situations where sizing props are based on a scale:

```js
{
  sizes: {
    "size-0": 0,
    "size-1": '1rem',
    "size-2": '2.5rem',
    "size-3": '4rem',
    ...
    "size-72: '400rem',
    "size-full": '100%',
  }
}
```

Most of the possible values would be missing due to the truncation