### PR TITLE
fix: Set preview mode public path correctly

### DIFF
--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -166,7 +166,7 @@ module.exports = async (playroomConfig, options) => {
         chunksSortMode: 'none',
         chunks: ['preview'],
         filename: 'preview/index.html',
-        base: playroomConfig.baseUrl || '/',
+        publicPath: '../',
       }),
       ...(options.production
         ? []


### PR DESCRIPTION
Mistakenly set the base path for the preview route rather than relatively referencing the parent folder of the preview document.