### PR TITLE
fix: Correct rule.use to an array

### DIFF
--- a/lib/makeDefaultWebpackConfig.js
+++ b/lib/makeDefaultWebpackConfig.js
@@ -5,15 +5,17 @@ module.exports = (playroomConfig) => ({
         test: /\.jsx?$/,
         include: playroomConfig.cwd,
         exclude: /node_modules/,
-        use: {
-          loader: require.resolve('babel-loader'),
-          options: {
-            presets: [
-              require.resolve('@babel/preset-env'),
-              require.resolve('@babel/preset-react'),
-            ],
+        use: [
+          {
+            loader: require.resolve('babel-loader'),
+            options: {
+              presets: [
+                require.resolve('@babel/preset-env'),
+                require.resolve('@babel/preset-react'),
+              ],
+            },
           },
-        },
+        ],
       },
     ],
   },

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -71,35 +71,39 @@ module.exports = async (playroomConfig, options) => {
         {
           test: /\.(ts|tsx)$/,
           include: includePaths,
-          use: {
-            loader: require.resolve('babel-loader'),
-            options: {
-              presets: [
-                [
-                  require.resolve('@babel/preset-env'),
-                  { shippedProposals: true },
+          use: [
+            {
+              loader: require.resolve('babel-loader'),
+              options: {
+                presets: [
+                  [
+                    require.resolve('@babel/preset-env'),
+                    { shippedProposals: true },
+                  ],
+                  require.resolve('@babel/preset-react'),
+                  require.resolve('@babel/preset-typescript'),
                 ],
-                require.resolve('@babel/preset-react'),
-                require.resolve('@babel/preset-typescript'),
-              ],
+              },
             },
-          },
+          ],
         },
         {
           test: /\.js$/,
           include: includePaths,
-          use: {
-            loader: require.resolve('babel-loader'),
-            options: {
-              presets: [
-                [
-                  require.resolve('@babel/preset-env'),
-                  { shippedProposals: true },
+          use: [
+            {
+              loader: require.resolve('babel-loader'),
+              options: {
+                presets: [
+                  [
+                    require.resolve('@babel/preset-env'),
+                    { shippedProposals: true },
+                  ],
+                  require.resolve('@babel/preset-react'),
                 ],
-                require.resolve('@babel/preset-react'),
-              ],
+              },
             },
-          },
+          ],
         },
         {
           test: /\.less$/,


### PR DESCRIPTION
According to [webpack documentation](https://webpack.js.org/configuration/module/#ruleuse), `rule.use` should be an array. I believe it was once allowed to be an object and is still backwards compatible.

For more background, I use [external-svg-sprite-loader](https://github.com/bensampaio/external-svg-sprite-loader) which iterates over the rules/loaders and expects `rule.use` to be an array per the webpack docs. Trying to use playroom but running into bensampaio/external-svg-sprite-loader#58 at the moment, this change should fix the issue.