### PR TITLE
fix: prevent exception on start when no TS config is found

### DIFF
--- a/lib/getStaticTypes.js
+++ b/lib/getStaticTypes.js
@@ -24,7 +24,6 @@ module.exports = async (playroomConfig) => {
   } = playroomConfig;
 
   const tsConfigPath = await findUp('tsconfig.json', { cwd });
-  const basePath = path.dirname(tsConfigPath);
 
   if (!tsConfigPath) {
     return {};
@@ -40,6 +39,7 @@ module.exports = async (playroomConfig) => {
     throw error;
   }
 
+  const basePath = path.dirname(tsConfigPath);
   const { options, errors } = ts.parseJsonConfigFileContent(
     config,
     ts.sys,


### PR DESCRIPTION
This PR should fix #247 

`undefined` is passed to `path.dirname`, on projects with no TS config file.   