### PR TITLE
Add `Access-Control-Allow-Origin` to playroom dev server

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -37,6 +37,9 @@ module.exports = async (config, callback) => {
       // Added to prevent Webpack HMR from breaking when iframeSandbox option is used
       // See: https://github.com/webpack/webpack-dev-server/issues/1604
       allowedHosts: 'all',
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+      },
     };
 
     const compiler = webpack(webpackConfig);


### PR DESCRIPTION
When attempting to import external fonts into playroom, I've been getting the following error:

<img width="624" alt="Screen Shot 2021-12-09 at 12 06 19 pm" src="https://user-images.githubusercontent.com/7336481/145315848-84b0c367-ce9c-412d-a974-ebe79c0101ef.png">

Not sure why my origin would be `null`, but it seems that adding `Access-Control-Allow-Origin` to the dev server config fixes the issue. 
