### PR TITLE
ci: Remove token from release checkout step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,8 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-          # This makes Actions fetch all Git history for semantic-release
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v2.2.2


### PR DESCRIPTION
Trying to get Version Packages PR to run workflow actions. Removing the token from the checkout step to align with the working implementation we have in [Vocab](https://github.com/seek-oss/vocab/blob/master/.github/workflows/release.yml).

🎲 