### PR TITLE
Add line editing keyboard shortcuts

### DIFF
--- a/.changeset/wicked-emus-jog.md
+++ b/.changeset/wicked-emus-jog.md
@@ -1,0 +1,11 @@
+---
+'playroom': minor
+---
+
+Adds VSCode-style keybindings for move line up/down and copy line up/down.
+Works for selections as well as single lines.
+
+See the VSCode keyboard shortcut reference for details ([Mac]/[Windows]).
+
+[mac]: https://code.visualstudio.com/shortcuts/keyboard-shortcuts-macos.pdf
+[windows]: https://code.visualstudio.com/shortcuts/keyboard-shortcuts-windows.pdf

--- a/src/Playroom/CodeEditor/CodeEditor.tsx
+++ b/src/Playroom/CodeEditor/CodeEditor.tsx
@@ -27,13 +27,16 @@ import 'codemirror/addon/fold/brace-fold';
 
 type DuplicationDirection = 'up' | 'down';
 
+const directionToMethod = {
+  up: 'to',
+  down: 'from',
+} as const;
+
 const getNewPosition = (
   range: CodeMirror.Range,
   direction: DuplicationDirection
 ) => {
-  const newPositionDirection = direction === 'up' ? 'from' : 'to';
-
-  const currentLine = range[newPositionDirection]().line;
+  const currentLine = range[directionToMethod[direction]]().line;
 
   const newLine = direction === 'up' ? currentLine + 1 : currentLine;
   return new Pos(newLine, 0);

--- a/src/Playroom/CodeEditor/CodeEditor.tsx
+++ b/src/Playroom/CodeEditor/CodeEditor.tsx
@@ -35,7 +35,7 @@ const getNewPosition = (
 
   const currentLine = range[newPositionDirection]().line;
 
-  const newLine = direction === 'up' ? currentLine : currentLine + 1;
+  const newLine = direction === 'up' ? currentLine + 1 : currentLine;
   return new Pos(newLine, 0);
 };
 

--- a/src/Playroom/CodeEditor/CodeEditor.tsx
+++ b/src/Playroom/CodeEditor/CodeEditor.tsx
@@ -25,12 +25,12 @@ import 'codemirror/addon/fold/foldcode';
 import 'codemirror/addon/fold/foldgutter';
 import 'codemirror/addon/fold/brace-fold';
 
-type DuplicationDirection = 'up' | 'down';
-
 const directionToMethod = {
   up: 'to',
   down: 'from',
 } as const;
+
+type DuplicationDirection = keyof typeof directionToMethod;
 
 const getNewPosition = (
   range: CodeMirror.Range,


### PR DESCRIPTION
The number of times I've tried to move a block of code up or down using Alt-Up in Playroom must be almost equal to the numbers of lines I've written in Playroom. It feels like checking my empty wrist when I've forgotten my watch.

These oversights have been corrected, and I have ascended to heights of programming efficiency hitherto undreamt of. And now you can too.

They work just like VSCode's versions.

<img width="422" alt="Screen Shot 2023-03-01 at 11 30 25 am" src="https://user-images.githubusercontent.com/36141055/222030720-ada9ac94-eb3d-4835-8b0b-b6eac116a9c5.png">

These implementations were mostly lifted from the codemirror5 [sublime text keymap], with a bit of editing to make them work how I think they should work.

[Preview site] for testing it out, or I've [snapshotted it into Braid][snap] if that's your preference.

[sublime text keymap]: https://codemirror.net/5/keymap/sublime.js
[preview site]: https://playroom--e4598cbf0f81ee80fc4d5f6ef0baa7e3f9677d8d.surge.sh
[snap]: http://braid-design-system--20c4cfa3bb050eedac63499c58cec0e28ee69777.surge.sh/playroom