### PR TITLE
Add a preview link to the GitHub action summary

### DIFF
--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v2.2.4
 
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v2.2.4
 
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v2.2.4
 
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v2.2.4
 
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "webpack-merge": "^5.8.0"
   },
   "devDependencies": {
+    "@actions/core": "^1.10.0",
     "@changesets/cli": "^2.25.2",
     "@octokit/rest": "^19.0.5",
     "@types/jest": "^29.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
+  '@actions/core': ^1.10.0
   '@babel/cli': ^7.19.3
   '@babel/core': ^7.20.5
   '@babel/preset-env': ^7.20.2
@@ -128,6 +129,7 @@ dependencies:
   webpack-merge: 5.8.0
 
 devDependencies:
+  '@actions/core': 1.10.0
   '@changesets/cli': 2.25.2
   '@octokit/rest': 19.0.5
   '@types/jest': 29.2.4
@@ -145,6 +147,19 @@ devDependencies:
   surge: 0.23.1
 
 packages:
+
+  /@actions/core/1.10.0:
+    resolution: {integrity: sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==}
+    dependencies:
+      '@actions/http-client': 2.0.1
+      uuid: 8.3.2
+    dev: true
+
+  /@actions/http-client/2.0.1:
+    resolution: {integrity: sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==}
+    dependencies:
+      tunnel: 0.0.6
+    dev: true
 
   /@ampproject/remapping/2.2.0:
     resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
@@ -8990,6 +9005,11 @@ packages:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
     dependencies:
       safe-buffer: 5.2.1
+    dev: true
+
+  /tunnel/0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
     dev: true
 
   /tweetnacl/0.14.5:

--- a/scripts/postCommitStatus.js
+++ b/scripts/postCommitStatus.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-console */
 const core = require('@actions/core');
 
-const writeSummary = async ({ title, message }) => {
+const writeSummary = async ({ title, link }) => {
   core.summary.addHeading(title, 3);
-  core.summary.addRaw(`<p>${message}</p>`, true);
+  core.summary.addLink(link, link);
 
   await core.summary.write();
 };
@@ -41,7 +41,7 @@ const writeSummary = async ({ title, message }) => {
 
     await writeSummary({
       title: 'Preview published',
-      message: `Playroom preview available at ${previewUrl}`,
+      link: previewUrl,
     });
   } catch (err) {
     console.error(err);

--- a/scripts/postCommitStatus.js
+++ b/scripts/postCommitStatus.js
@@ -1,4 +1,13 @@
 /* eslint-disable no-console */
+const core = require('@actions/core');
+
+const writeSummary = async ({ title, message }) => {
+  core.summary.addHeading(title, 3);
+  core.summary.addRaw(`<p>${message}</p>`, true);
+
+  await core.summary.write();
+};
+
 (async () => {
   try {
     console.log('Posting commit status to GitHub...');
@@ -16,17 +25,24 @@
       auth: GITHUB_TOKEN,
     });
 
+    const previewUrl = `https://playroom--${GITHUB_SHA}.surge.sh`;
+
     await octokit.repos.createCommitStatus({
       owner: 'seek-oss',
       repo: 'playroom',
       sha: GITHUB_SHA,
       state: 'success',
       context: 'Preview Site',
-      target_url: `https://playroom--${GITHUB_SHA}.surge.sh`,
+      target_url: previewUrl,
       description: 'The preview for this PR has been successfully deployed',
     });
 
     console.log('Successfully posted commit status to GitHub');
+
+    await writeSummary({
+      title: 'Preview published',
+      message: `Playroom preview available at ${previewUrl}`,
+    });
   } catch (err) {
     console.error(err);
     process.exit(1); // eslint-disable-line no-process-exit


### PR DESCRIPTION
Currently, when a preview deploy gets published, the link is added as a PR status to be a little easier to find. This isn't all that helpful if you don't have a PR yet, and digging around in the action logs isn't ideal either.

Have added the link to an action summary, similar to changesets-snapshot.

<img width="685" alt="Screen Shot 2023-03-05 at 10 22 06 am" src="https://user-images.githubusercontent.com/36141055/222933136-e282573f-01a1-4fd3-87b1-4f48ce1877c2.png">

I've also upgraded the pnpm action in this PR, as the existing version used deprecated actions API, so the [warning annotations] that used to come up [don't anymore].

[warning annotations]: https://github.com/seek-oss/playroom/actions/runs/4333280893
[don't anymore]: https://github.com/seek-oss/playroom/actions/runs/4333287804