### PR TITLE
:sparkles: add new config variable "defaultWidths"

### DIFF
--- a/src/Playroom/Playroom.tsx
+++ b/src/Playroom/Playroom.tsx
@@ -50,10 +50,11 @@ export interface PlayroomProps {
   components: Record<string, ComponentType>;
   themes: string[];
   widths: number[];
+  defaultWidths: number[];
   snippets: Snippets;
 }
 
-export default ({ components, themes, widths, snippets }: PlayroomProps) => {
+export default ({ components, themes, widths, defaultWidths, snippets }: PlayroomProps) => {
   const [
     {
       editorPosition,
@@ -173,7 +174,7 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
             visibleThemes && visibleThemes.length > 0 ? visibleThemes : themes
           }
           widths={
-            visibleWidths && visibleWidths.length > 0 ? visibleWidths : widths
+            visibleWidths && visibleWidths.length > 0 ? visibleWidths : defaultWidths ?? widths
           }
         />
         <div

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const polyfillIntersectionObserver = () =>
 
 polyfillIntersectionObserver().then(() => {
   const widths = playroomConfig.widths || [320, 375, 768, 1024];
+  const defaultWidths = playroomConfig.defaultWidths;
 
   const outlet = document.createElement('div');
   document.body.appendChild(outlet);
@@ -31,6 +32,7 @@ polyfillIntersectionObserver().then(() => {
         <Playroom
           components={filteredComponents}
           widths={widths}
+          defaultWidths={defaultWidths}
           themes={themeNames}
           snippets={
             typeof snippets.default !== 'undefined'


### PR DESCRIPTION
# What and Why?

Allow default widths to be set to something other than "show all the widths available", since we support a lot of breakpoints, but for the average developer using our design system it's a bit overwhelming to see all of them + horizontal scroll when they are _usually_ just interested in one or two breakpoints (for us it's usually a mobile width + generic desktop widths).

<img width="1800" alt="image" src="https://github.com/seek-oss/playroom/assets/819074/c5767faf-7554-4ddd-a1bf-80fb27afa0df">


# How?

introduces a configuration variable `defaultWidths` that becomes the viewports rendered when you have no width check mark selected in the sidebar (as shown in the screenshot above).

```javascript
module.exports = {
  // ...
  widths: [320, 480, 768, 1024, 1280, 1440],
  defaultWidths: [320, 1280]
};

```