### PR TITLE
Make the error marker hoverable

### DIFF
--- a/.changeset/thick-mails-poke.md
+++ b/.changeset/thick-mails-poke.md
@@ -2,4 +2,4 @@
 'playroom': patch
 ---
 
-Make the error marker hoverable
+Improve affordance of error marker detail

--- a/.changeset/thick-mails-poke.md
+++ b/.changeset/thick-mails-poke.md
@@ -1,0 +1,5 @@
+---
+'playroom': patch
+---
+
+Make the error marker hoverable

--- a/src/Playroom/CodeEditor/CodeEditor.css.ts
+++ b/src/Playroom/CodeEditor/CodeEditor.css.ts
@@ -23,6 +23,9 @@ export const errorMarker = style([
     opacity: 0,
   }),
   {
+    ':hover': {
+      cursor: 'pointer',
+    },
     backgroundColor: colorPaletteVars.background.critical,
     color: colorPaletteVars.foreground.critical,
     minWidth: minimumLineNumberWidth,

--- a/src/Playroom/CodeEditor/CodeEditor.css.ts
+++ b/src/Playroom/CodeEditor/CodeEditor.css.ts
@@ -24,7 +24,7 @@ export const errorMarker = style([
   }),
   {
     ':hover': {
-      cursor: 'pointer',
+      cursor: 'help',
     },
     backgroundColor: colorPaletteVars.background.critical,
     color: colorPaletteVars.foreground.critical,


### PR DESCRIPTION
Currently there's no way to tell that there's a tooltip on the error marker, other than waiting