### PR TITLE
Fix `playroom build` by making favicon path relative to webpack config

### DIFF
--- a/.changeset/six-spoons-change.md
+++ b/.changeset/six-spoons-change.md
@@ -1,0 +1,5 @@
+---
+'playroom': patch
+---
+
+Fix `playroom build` by making favicon path relative to webpack config

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -167,7 +167,7 @@ module.exports = async (playroomConfig, options) => {
         chunksSortMode: 'none',
         chunks: ['index'],
         filename: 'index.html',
-        favicon: 'images/favicon.png',
+        favicon: path.join(__dirname, '../images/favicon.png'),
         base: playroomConfig.baseUrl,
       }),
       new HtmlWebpackPlugin({


### PR DESCRIPTION
https://github.com/seek-oss/playroom/pull/309 seems to have broken `playroom build`. This wasn't caught during CI as the preview build runs a script from the repo root, so the path resolves correctly. However it's incorrect in any other case, e.g. using `playroom` as a dependency.

Have confirmed that this fix works by testing [Braid](https://github.com/seek-oss/braid-design-system)'s playroom build.

Ideally we'd have proper fixtures (i.e. make the repo into a monorepo) that we could test in isolation, but we're not there yet.

Fixes #311.