### PR TITLE
Fix bug in "Wrap selection in tag" command

### DIFF
--- a/.changeset/young-turkeys-turn.md
+++ b/.changeset/young-turkeys-turn.md
@@ -1,0 +1,5 @@
+---
+'playroom': patch
+---
+
+Fix bug in "Wrap selection in tag" command that caused the start cursor to occasionally be placed in the wrong postion.

--- a/cypress/e2e/keymaps.cy.js
+++ b/cypress/e2e/keymaps.cy.js
@@ -216,6 +216,21 @@ describe('Keymaps', () => {
       `);
     });
 
+    it('should ignore surrounding whitespace when wrapping a single line selection', () => {
+      typeCode(' ');
+      typeCode('{leftArrow}');
+      selectToEndOfLine();
+
+      typeCode(`{shift+${modifierKey}+,}`);
+      typeCode('span');
+
+      assertCodePaneContains(dedent`
+        <span> <div>First line</div></span>
+        <div>Second line</div>
+        <div>Third line</div>
+      `);
+    });
+
     it('should wrap a multi-line selection', () => {
       typeCode('{shift+downArrow}');
       selectToEndOfLine();

--- a/src/Playroom/CodeEditor/keymaps/wrap.ts
+++ b/src/Playroom/CodeEditor/keymaps/wrap.ts
@@ -26,7 +26,6 @@ export const wrapInTag = (cm: Editor) => {
     const existingContent = cm.getRange(from, to);
     const existingIndent =
       existingContent.length - existingContent.trimStart().length;
-    const leadingWhitespace = existingContent.match(/^[ \t]+/)?.[0].length ?? 0;
 
     const isMultiLineSelection = to.line !== from.line;
 
@@ -37,13 +36,13 @@ export const wrapInTag = (cm: Editor) => {
       existingIndent,
     });
 
+    const startCursorCharacterPosition =
+      from.ch + 1 + (isMultiLineSelection ? existingIndent : 0);
     const newStartCursor = new Pos(
       from.line + linesAdded,
-      from.ch +
-        existingIndent +
-        1 -
-        (isMultiLineSelection ? 0 : leadingWhitespace)
+      startCursorCharacterPosition
     );
+
     const newEndCursor = isMultiLineSelection
       ? new Pos(to.line + linesAdded + 2, from.ch + existingIndent + 2)
       : new Pos(to.line + linesAdded, to.ch + 4);

--- a/src/Playroom/CodeEditor/keymaps/wrap.ts
+++ b/src/Playroom/CodeEditor/keymaps/wrap.ts
@@ -26,6 +26,7 @@ export const wrapInTag = (cm: Editor) => {
     const existingContent = cm.getRange(from, to);
     const existingIndent =
       existingContent.length - existingContent.trimStart().length;
+    const leadingWhitespace = existingContent.match(/^[ \t]+/)?.[0].length ?? 0;
 
     const isMultiLineSelection = to.line !== from.line;
 
@@ -38,7 +39,10 @@ export const wrapInTag = (cm: Editor) => {
 
     const newStartCursor = new Pos(
       from.line + linesAdded,
-      from.ch + existingIndent + 1
+      from.ch +
+        existingIndent +
+        1 -
+        (isMultiLineSelection ? 0 : leadingWhitespace)
     );
     const newEndCursor = isMultiLineSelection
       ? new Pos(to.line + linesAdded + 2, from.ch + existingIndent + 2)


### PR DESCRIPTION
When using the "Wrap selection in tag" command (`⌘` + `⇧` + `,`) on a single line of text that includes leading whitespace, the start cursor ends up in the wrong position:

https://github.com/seek-oss/playroom/assets/33821218/34c25a8d-dd82-46f3-9e51-893c496a32e3

This change subtracts the leading whitespace when calculating the position of the start cursor.