### PR TITLE
Prevent new Playroom tabs from loading previously used titles

### DIFF
--- a/.changeset/popular-dingos-walk.md
+++ b/.changeset/popular-dingos-walk.md
@@ -1,0 +1,5 @@
+---
+'playroom': patch
+---
+
+Fix an issue where new Playroom tabs without a set title would load a recently used title.

--- a/src/StoreContext/StoreContext.tsx
+++ b/src/StoreContext/StoreContext.tsx
@@ -478,7 +478,6 @@ export const StoreProvider = ({
       store.getItem<number[]>('visibleWidths'),
       store.getItem<string[]>('visibleThemes'),
       store.getItem<ColorScheme>('colorScheme'),
-      store.getItem<string | undefined>('title'),
     ]).then(
       ([
         storedCode,
@@ -488,7 +487,6 @@ export const StoreProvider = ({
         storedVisibleWidths,
         storedVisibleThemes,
         storedColorScheme,
-        storedTitle,
       ]) => {
         const code = codeFromQuery || storedCode || exampleCode;
         const editorPosition = storedPosition;
@@ -515,7 +513,7 @@ export const StoreProvider = ({
             ...(visibleThemes ? { visibleThemes } : {}),
             ...(visibleWidths ? { visibleWidths } : {}),
             ...(colorScheme ? { colorScheme } : {}),
-            title: titleFromQuery ?? storedTitle ?? undefined,
+            title: titleFromQuery,
             ready: true,
           },
         });

--- a/src/StoreContext/StoreContext.tsx
+++ b/src/StoreContext/StoreContext.tsx
@@ -388,7 +388,6 @@ const createReducer =
 
       case 'updateTitle': {
         const { title } = action.payload;
-        store.setItem('title', title);
 
         return {
           ...state,


### PR DESCRIPTION
Prevent new Playroom tabs with no set title from loading a recently used title.
New Playroom tabs should now have no set title by default.