### PR TITLE
Remove unnecessary "waits" in Cypress tests

### DIFF
--- a/cypress/e2e/editor.cy.js
+++ b/cypress/e2e/editor.cy.js
@@ -1,6 +1,7 @@
 import {
   formatCode,
   typeCode,
+  typeCodeWithDelay,
   assertFirstFrameContains,
   assertCodePaneContains,
   assertCodePaneLineCount,
@@ -21,7 +22,7 @@ describe('Editor', () => {
   });
 
   it('autocompletes', () => {
-    typeCode('<F{enter} c{enter}={downarrow}{enter} />');
+    typeCodeWithDelay('<F{enter} c{enter}={downarrow}{enter} />');
     assertFirstFrameContains('Foo');
     assertCodePaneContains('<Foo color="blue" />');
   });

--- a/cypress/e2e/scope.cy.js
+++ b/cypress/e2e/scope.cy.js
@@ -1,5 +1,5 @@
 import {
-  typeCode,
+  typeCodeWithDelay,
   assertFirstFrameContains,
   loadPlayroom,
 } from '../support/utils';
@@ -10,7 +10,7 @@ describe('useScope', () => {
   });
 
   it('works', () => {
-    typeCode('{{}hello()} {{}world()}', { delay: 0 });
+    typeCodeWithDelay('{{}hello()} {{}world()}');
     assertFirstFrameContains('HELLO WORLD');
   });
 });

--- a/cypress/e2e/snippets.cy.js
+++ b/cypress/e2e/snippets.cy.js
@@ -1,6 +1,7 @@
 import dedent from 'dedent';
 import {
   typeCode,
+  typeCodeWithDelay,
   assertFirstFrameContains,
   assertCodePaneContains,
   assertCodePaneLineCount,
@@ -55,7 +56,7 @@ describe('Snippets', () => {
           </span>
         </div>\n
       `);
-    typeCode('cursor position');
+    typeCodeWithDelay('cursor position');
     assertCodePaneContains(dedent`
         <div>
           Initial{" "}
@@ -68,12 +69,12 @@ describe('Snippets', () => {
 
   it('driven with keyboard', () => {
     // Open and format for insertion point
-    typeCode(`${isMac() ? '{cmd}' : '{ctrl}'}k`);
+    typeCodeWithDelay(`${isMac() ? '{cmd}' : '{ctrl}'}k`);
     assertSnippetsListIsVisible();
     assertCodePaneLineCount(8);
     filterSnippets('{esc}');
     assertCodePaneLineCount(1);
-    typeCode(`${isMac() ? '{cmd}' : '{ctrl}'}k`);
+    typeCodeWithDelay(`${isMac() ? '{cmd}' : '{ctrl}'}k`);
     assertSnippetsListIsVisible();
     assertCodePaneLineCount(8);
 
@@ -92,7 +93,7 @@ describe('Snippets', () => {
     assertCodePaneLineCount(1);
 
     // Re-open and persist
-    typeCode(`${isMac() ? '{cmd}' : '{ctrl}'}k`);
+    typeCodeWithDelay(`${isMac() ? '{cmd}' : '{ctrl}'}k`);
     filterSnippets('{downarrow}{downarrow}{downarrow}{downarrow}{enter}');
     assertFirstFrameContains('Initial code\nBar\nBlue Bar');
     assertCodePaneLineCount(7);
@@ -104,7 +105,7 @@ describe('Snippets', () => {
           </span>
         </div>\n
       `);
-    typeCode('cursor position');
+    typeCodeWithDelay('cursor position');
     assertCodePaneContains(dedent`
         <div>
           Initial{" "}

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -26,7 +26,10 @@ export const visit = (url) =>
       );
     });
 
-export const typeCode = (code, { delay = 200 } = {}) =>
+export const typeCode = (code) =>
+  getCodeEditor().focused().type(code, { force: true });
+
+export const typeCodeWithDelay = (code, { delay = 200 } = {}) =>
   getCodeEditor()
     .focused()
     .type(code, { force: true, delay })
@@ -35,8 +38,8 @@ export const typeCode = (code, { delay = 200 } = {}) =>
 export const formatCode = () =>
   getCodeEditor()
     .focused()
-    .type(`${isMac() ? '{cmd}' : '{ctrl}'}s`)
-    .wait(WAIT_FOR_FRAME_TO_RENDER);
+    .type(`${isMac() ? '{cmd}' : '{ctrl}'}s`);
+// .wait(WAIT_FOR_FRAME_TO_RENDER);
 
 export const selectWidthPreferenceByIndex = (index) =>
   cy
@@ -60,6 +63,7 @@ export const toggleSnippets = () =>
 
 export const filterSnippets = (search) => {
   cy.get('[data-testid="filterSnippets"]').type(search, { force: true });
+  // Todo - check if this wait necessary
   // eslint-disable-next-line @finsit/cypress/no-unnecessary-waiting
   cy.wait(200);
 };

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -39,7 +39,6 @@ export const formatCode = () =>
   getCodeEditor()
     .focused()
     .type(`${isMac() ? '{cmd}' : '{ctrl}'}s`);
-// .wait(WAIT_FOR_FRAME_TO_RENDER);
 
 export const selectWidthPreferenceByIndex = (index) =>
   cy
@@ -63,7 +62,6 @@ export const toggleSnippets = () =>
 
 export const filterSnippets = (search) => {
   cy.get('[data-testid="filterSnippets"]').type(search, { force: true });
-  // Todo - check if this wait necessary
   // eslint-disable-next-line @finsit/cypress/no-unnecessary-waiting
   cy.wait(200);
 };


### PR DESCRIPTION
Cypress no longer requires "wait" usage for most situations. This change removes it for as many cases as possible, making tests run much faster.