### PR TITLE
Improve keyboard shortcuts order

### DIFF
--- a/.changeset/eighty-pears-deny.md
+++ b/.changeset/eighty-pears-deny.md
@@ -1,0 +1,5 @@
+---
+'playroom': minor
+---
+
+In the Settings Panel, sort keyboard shortcuts order by most frequently and widely used. Related shortcuts are grouped together.

--- a/.changeset/eighty-pears-deny.md
+++ b/.changeset/eighty-pears-deny.md
@@ -1,5 +1,5 @@
 ---
-'playroom': minor
+'playroom': patch
 ---
 
 In the Settings Panel, sort keyboard shortcuts order by most frequently and widely used. Related shortcuts are grouped together.

--- a/src/Playroom/SettingsPanel/SettingsPanel.tsx
+++ b/src/Playroom/SettingsPanel/SettingsPanel.tsx
@@ -24,21 +24,18 @@ const getKeyBindings = () => {
   const metaKeySymbol = isMac() ? '⌘' : 'Ctrl';
   const altKeySymbol = isMac() ? '⌥' : 'Alt';
 
-  // Sort shortcuts alphabetically
-  /* eslint sort-keys: "error" */
   return {
-    'Add cursor to next line': [metaKeySymbol, altKeySymbol, '↓'],
-    'Add cursor to prev line': [metaKeySymbol, altKeySymbol, '↑'],
-    'Duplicate line down': ['⇧', altKeySymbol, '↓'],
-    'Duplicate line up': ['⇧', altKeySymbol, '↑'],
     'Format code': [metaKeySymbol, 'S'],
-    'Select next occurrence': [metaKeySymbol, 'D'],
-    'Swap line down': [altKeySymbol, '↓'],
-    'Swap line up': [altKeySymbol, '↑'],
     'Toggle comment': [metaKeySymbol, '/'],
     'Wrap selection in tag': [metaKeySymbol, '⇧', ','],
+    'Select next occurrence': [metaKeySymbol, 'D'],
+    'Swap line up': [altKeySymbol, '↑'],
+    'Swap line down': [altKeySymbol, '↓'],
+    'Duplicate line up': ['⇧', altKeySymbol, '↑'],
+    'Duplicate line down': ['⇧', altKeySymbol, '↓'],
+    'Add cursor to prev line': [metaKeySymbol, altKeySymbol, '↑'],
+    'Add cursor to next line': [metaKeySymbol, altKeySymbol, '↓'],
   };
-  /* eslint-disable sort-keys */
 };
 
 const positionIcon: Record<EditorPosition, ReactChild> = {

--- a/src/Playroom/SettingsPanel/SettingsPanel.tsx
+++ b/src/Playroom/SettingsPanel/SettingsPanel.tsx
@@ -25,9 +25,9 @@ const getKeyBindings = () => {
   const altKeySymbol = isMac() ? '⌥' : 'Alt';
 
   return {
-    'Format code': [metaKeySymbol, 'S'],
     'Toggle comment': [metaKeySymbol, '/'],
     'Wrap selection in tag': [metaKeySymbol, '⇧', ','],
+    'Format code': [metaKeySymbol, 'S'],
     'Select next occurrence': [metaKeySymbol, 'D'],
     'Swap line up': [altKeySymbol, '↑'],
     'Swap line down': [altKeySymbol, '↓'],


### PR DESCRIPTION
This change sorts shortcuts by most frequently and most widely used, instead of alphabetical order.
More advanced shortcuts (mainly for developers) are moved to the bottom of the list.
Related shortcuts (e.g. "Add cursor to next line" and "Add cursor to prev line") are kept together. 