### PR TITLE
Replace `query-string` dependency with `URLSearchParams`

### DIFF
--- a/.changeset/early-dogs-peel.md
+++ b/.changeset/early-dogs-peel.md
@@ -1,0 +1,5 @@
+---
+'playroom': patch
+---
+
+Replace `query-string` dependency with `URLSearchParams`

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "portfinder": "^1.0.32",
     "prettier": "^2.8.1",
     "prop-types": "^15.8.1",
-    "query-string": "^7.1.3",
     "re-resizable": "^6.9.9",
     "react-docgen-typescript": "^2.2.2",
     "react-helmet": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,9 +131,6 @@ dependencies:
   prop-types:
     specifier: ^15.8.1
     version: 15.8.1
-  query-string:
-    specifier: ^7.1.3
-    version: 7.1.3
   re-resizable:
     specifier: ^6.9.9
     version: 6.9.9(react-dom@18.2.0)(react@18.2.0)
@@ -4506,11 +4503,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /decode-uri-component@0.2.2:
-    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
-    engines: {node: '>=0.10'}
-    dev: false
-
   /dedent@0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
     dev: true
@@ -5459,11 +5451,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
-
-  /filter-obj@1.1.0:
-    resolution: {integrity: sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==}
-    engines: {node: '>=0.10.0'}
-    dev: false
 
   /finalhandler@1.2.0:
     resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
@@ -8145,16 +8132,6 @@ packages:
     engines: {node: '>=0.6'}
     dev: true
 
-  /query-string@7.1.3:
-    resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
-    engines: {node: '>=6'}
-    dependencies:
-      decode-uri-component: 0.2.2
-      filter-obj: 1.1.0
-      split-on-first: 1.1.0
-      strict-uri-encode: 2.0.0
-    dev: false
-
   /querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
     dev: true
@@ -9042,11 +9019,6 @@ packages:
       - supports-color
     dev: false
 
-  /split-on-first@1.1.0:
-    resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
-    engines: {node: '>=6'}
-    dev: false
-
   /split@0.3.1:
     resolution: {integrity: sha512-hCHXkQDs1HFKRsrT9EutGT1hmjS1FW1Aei8dk/CxrT7mslcMtAxbiv8LYA/AYDvjB6h9rSXgW8zAZwg20tKMTw==}
     dependencies:
@@ -9149,11 +9121,6 @@ packages:
     dependencies:
       mixme: 0.5.4
     dev: true
-
-  /strict-uri-encode@2.0.0:
-    resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
-    engines: {node: '>=4'}
-    dev: false
 
   /string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}

--- a/src/Playroom/Frame.tsx
+++ b/src/Playroom/Frame.tsx
@@ -19,11 +19,15 @@ export default function Frame({
   components,
   FrameComponent,
 }: FrameProps) {
-  const { themeName, code } = useParams((rawParams) => ({
-    themeName:
-      typeof rawParams.themeName === 'string' ? rawParams.themeName : '',
-    code: typeof rawParams.code === 'string' ? rawParams.code : '',
-  }));
+  const { themeName, code } = useParams((rawParams) => {
+    const rawThemeName = rawParams.get('themeName');
+    const rawCode = rawParams.get('code');
+
+    return {
+      themeName: rawThemeName || '',
+      code: rawCode || '',
+    };
+  });
 
   const resolvedThemeName =
     themeName === '__PLAYROOM__NO_THEME__' ? null : themeName;

--- a/src/Playroom/Preview.tsx
+++ b/src/Playroom/Preview.tsx
@@ -28,9 +28,10 @@ export interface PreviewProps {
 }
 export default ({ themes, components, FrameComponent }: PreviewProps) => {
   const { themeName, code, title } = useParams((rawParams): PreviewState => {
-    if (rawParams.code) {
+    const rawCode = rawParams.get('code');
+    if (rawCode) {
       const result = JSON.parse(
-        lzString.decompressFromEncodedURIComponent(String(rawParams.code)) ?? ''
+        lzString.decompressFromEncodedURIComponent(String(rawCode)) ?? ''
       );
 
       return {

--- a/src/StoreContext/StoreContext.tsx
+++ b/src/StoreContext/StoreContext.tsx
@@ -453,14 +453,15 @@ export const StoreProvider = ({
     let widthsFromQuery: State['visibleWidths'];
     let titleFromQuery: State['title'];
 
-    if (params.code) {
+    const paramsCode = params.get('code');
+    if (paramsCode) {
       const {
         code: parsedCode,
         themes: parsedThemes,
         widths: parsedWidths,
         title: parsedTitle,
       } = JSON.parse(
-        lzString.decompressFromEncodedURIComponent(String(params.code)) ?? ''
+        lzString.decompressFromEncodedURIComponent(String(paramsCode)) ?? ''
       );
 
       codeFromQuery = parsedCode;

--- a/src/utils/params.ts
+++ b/src/utils/params.ts
@@ -1,6 +1,5 @@
 import { createBrowserHistory } from 'history';
 import { useState, useEffect } from 'react';
-import queryString, { type ParsedQuery } from 'query-string';
 
 import playroomConfig from '../config';
 
@@ -11,10 +10,8 @@ export function updateUrlCode(code: string) {
 
   const existingQuery = getParamsFromQuery();
 
-  const newQuery = queryString.stringify({
-    ...existingQuery,
-    code,
-  });
+  const newQuery = new URLSearchParams(existingQuery);
+  newQuery.set('code', code);
 
   const params =
     playroomConfig.paramType === 'hash' ? `#?${newQuery}` : `?${newQuery}`;
@@ -24,18 +21,18 @@ export function updateUrlCode(code: string) {
 
 export function getParamsFromQuery(location = history.location) {
   try {
-    return queryString.parse(
+    return new URLSearchParams(
       playroomConfig.paramType === 'hash'
         ? location.hash.replace(/^#/, '')
         : location.search
     );
   } catch (err) {
-    return {};
+    return new URLSearchParams();
   }
 }
 
 export function useParams<ReturnType>(
-  selector: (rawParams: ParsedQuery) => ReturnType
+  selector: (rawParams: URLSearchParams) => ReturnType
 ): ReturnType {
   const [params, setParams] = useState(getParamsFromQuery);
 


### PR DESCRIPTION
The platform-native `URLSearchParams` has broad browser support, so we don't really have a need for `query-string` anymore.