### PR TITLE
Fix async import of playroom config on Windows

### DIFF
--- a/.changeset/tiny-plums-develop.md
+++ b/.changeset/tiny-plums-develop.md
@@ -1,0 +1,5 @@
+---
+'playroom': patch
+---
+
+Fix async import of playroom config on Windows

--- a/bin/cli.cjs
+++ b/bin/cli.cjs
@@ -4,6 +4,7 @@ const commandLineArgs = require('command-line-args');
 const commandLineUsage = require('command-line-usage');
 const findUp = require('find-up');
 const lib = require('../lib');
+const url = require('url');
 
 const showUsage = () => {
   console.log(
@@ -65,7 +66,7 @@ const showUsage = () => {
     process.exit(1);
   }
 
-  const { default: config } = await import(configPath);
+  const { default: config } = await import(url.pathToFileURL(configPath));
 
   const playroom = lib({
     cwd: path.dirname(configPath),


### PR DESCRIPTION
Fixes #307.

When working with windows paths, a path like `C:\foo\bar` will be misinterpreted by `import`. It interprets the path as a URL and thinks `C:` is a protocol. [`url.pathToFileURL`](https://nodejs.org/api/url.html#urlpathtofileurlpath) addresses this by converting the path to a proper file URL, which `import` interprets correctly.