### PR TITLE
Refactor logic to determine comment type for "Toggle comment" command

### DIFF
--- a/.changeset/many-trains-cheat.md
+++ b/.changeset/many-trains-cheat.md
@@ -1,0 +1,5 @@
+---
+'playroom': patch
+---
+
+Fix issue with "Toggle comment" command commenting certain code outside JSX tags with incorrect syntax.

--- a/cypress/e2e/keymaps.cy.js
+++ b/cypress/e2e/keymaps.cy.js
@@ -412,7 +412,7 @@ describe('Keymaps', () => {
           >
             Text
           </button>
-          `);
+        `);
 
         moveBy(0, 2);
 
@@ -427,6 +427,76 @@ describe('Keymaps', () => {
           >
             Text
           </button>
+        `);
+      });
+
+      it('block - expression slot outside tags', () => {
+        loadPlayroom(`
+          {testFn('test')}
+          <div>First line</div>
+          <div>Second line</div>
+          <div>Third line</div>
+        `);
+
+        executeToggleCommentCommand();
+
+        assertCodePaneContains(dedent`
+          {/* {testFn('test')} */}
+          <div>First line</div>
+          <div>Second line</div>
+          <div>Third line</div>
+        `);
+      });
+
+      it('line - inside multi-line expression slot outside tags', () => {
+        loadPlayroom(`
+          {
+            testFn('test')
+          }
+          <div>First line</div>
+          <div>Second line</div>
+          <div>Third line</div>
+        `);
+
+        moveBy(0, 1);
+
+        executeToggleCommentCommand();
+
+        assertCodePaneContains(dedent`
+          {
+            // testFn('test')
+          }
+          <div>First line</div>
+          <div>Second line</div>
+          <div>Third line</div>
+        `);
+      });
+
+      it('line - full line expression slot inside tags', () => {
+        loadPlayroom(`
+          <div
+            prop1="prop1"
+            {...props}
+          >
+            First line
+          </div>
+          <div>Second line</div>
+          <div>Third line</div>
+        `);
+
+        moveBy(0, 2);
+
+        executeToggleCommentCommand();
+
+        assertCodePaneContains(dedent`
+          <div
+            prop1="prop1"
+            // {...props}
+          >
+            First line
+          </div>
+          <div>Second line</div>
+          <div>Third line</div>
         `);
       });
     });

--- a/src/Playroom/CodeEditor/keymaps/comment.ts
+++ b/src/Playroom/CodeEditor/keymaps/comment.ts
@@ -243,6 +243,7 @@ const determineCommentType = (
     cm.getLine(to.line).trimEnd().endsWith(BLOCK_COMMENT_END);
 
   if (isFullExpressionSlot(lineTokens)) {
+  if (!isBlockComment && isFullExpressionSlot(lineTokens)) {
     return isJavaScriptMode ? 'block' : 'line';
   }
 

--- a/src/Playroom/CodeEditor/keymaps/comment.ts
+++ b/src/Playroom/CodeEditor/keymaps/comment.ts
@@ -198,6 +198,18 @@ function getUpdatedContent(existingContent: string, range: TagRange) {
 
 type CommentType = 'line' | 'block';
 
+const isOnlyWhitespace = (input: string) => /^\s+$/.test(input);
+
+const isFullExpressionSlot = (tokens: CodeMirror.Token[]) => {
+  const formattedLine = tokens.filter(
+    (token) => token.type !== 'comment' && !isOnlyWhitespace(token.string)
+  );
+
+  return (
+    formattedLine.at(0)?.string === '{' && formattedLine.at(-1)?.string === '}'
+  );
+};
+
 interface TagRange {
   from: CodeMirror.Position;
   to: CodeMirror.Position;
@@ -229,6 +241,10 @@ const determineCommentType = (
   const isBlockComment =
     cm.getLine(from.line).trimStart().startsWith(BLOCK_COMMENT_START) &&
     cm.getLine(to.line).trimEnd().endsWith(BLOCK_COMMENT_END);
+
+  if (isFullExpressionSlot(lineTokens)) {
+    return isJavaScriptMode ? 'block' : 'line';
+  }
 
   if (isInlineComment) {
     return 'line';

--- a/src/Playroom/CodeEditor/keymaps/comment.ts
+++ b/src/Playroom/CodeEditor/keymaps/comment.ts
@@ -206,7 +206,8 @@ const isFullExpressionSlot = (tokens: CodeMirror.Token[]) => {
   );
 
   return (
-    formattedLineTokens.at(0)?.string === '{' && formattedLineTokens.at(-1)?.string === '}'
+    formattedLineTokens.at(0)?.string === '{' &&
+    formattedLineTokens.at(-1)?.string === '}'
   );
 };
 

--- a/src/Playroom/CodeEditor/keymaps/comment.ts
+++ b/src/Playroom/CodeEditor/keymaps/comment.ts
@@ -201,12 +201,12 @@ type CommentType = 'line' | 'block';
 const isOnlyWhitespace = (input: string) => /^\s+$/.test(input);
 
 const isFullExpressionSlot = (tokens: CodeMirror.Token[]) => {
-  const formattedLine = tokens.filter(
+  const formattedLineTokens = tokens.filter(
     (token) => token.type !== 'comment' && !isOnlyWhitespace(token.string)
   );
 
   return (
-    formattedLine.at(0)?.string === '{' && formattedLine.at(-1)?.string === '}'
+    formattedLineTokens.at(0)?.string === '{' && formattedLineTokens.at(-1)?.string === '}'
   );
 };
 

--- a/src/Playroom/CodeEditor/keymaps/comment.ts
+++ b/src/Playroom/CodeEditor/keymaps/comment.ts
@@ -219,7 +219,9 @@ const determineCommentType = (
     (token) => token.type === 'attribute'
   );
 
-  const isJavaScriptMode = cm.getModeAt(from).name === 'javascript';
+  const isJavaScriptMode =
+    cm.getModeAt(new Pos(from.line, 0)).name === 'javascript';
+
   const isInlineComment = cm
     .getLine(from.line)
     .trimStart()

--- a/src/Playroom/CodeEditor/keymaps/comment.ts
+++ b/src/Playroom/CodeEditor/keymaps/comment.ts
@@ -242,7 +242,6 @@ const determineCommentType = (
     cm.getLine(from.line).trimStart().startsWith(BLOCK_COMMENT_START) &&
     cm.getLine(to.line).trimEnd().endsWith(BLOCK_COMMENT_END);
 
-  if (isFullExpressionSlot(lineTokens)) {
   if (!isBlockComment && isFullExpressionSlot(lineTokens)) {
     return isJavaScriptMode ? 'block' : 'line';
   }


### PR DESCRIPTION
Fixes an issue where full line expression slots outside any JSX tags would be line commented rather than block commented.

# Example of problem
https://github.com/seek-oss/playroom/assets/33821218/211da86d-31cc-438e-a823-645295b18daa