### PR TITLE
Fix reliability issues in Cypress tests for search related keyboard shortcuts

### DIFF
--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -189,18 +189,14 @@ export const loadPlayroom = (initialCode) => {
 };
 
 const typeInSearchField = (text) =>
-  /*
-  force true is required because cypress incorrectly and intermittently
-  reports that search field is covered by another element
-  */
-  cy.get('.CodeMirror-search-field').type(text, { force: true });
+  cy.get('.CodeMirror-search-field').type(text);
 
 /**
  * @param {string} term
  */
 export const findInCode = (term) => {
   // Wait necessary to ensure code pane is focussed
-  cy.wait(200); // eslint-disable-line @finsit/cypress/no-unnecessary-waiting
+  cy.wait(500); // eslint-disable-line @finsit/cypress/no-unnecessary-waiting
   typeCode(`{${cmdPlus('f')}}`);
 
   typeInSearchField(`${term}{enter}`);
@@ -212,7 +208,7 @@ export const findInCode = (term) => {
  */
 export const replaceInCode = (term, replaceWith) => {
   // Wait necessary to ensure code pane is focussed
-  cy.wait(200); // eslint-disable-line @finsit/cypress/no-unnecessary-waiting
+  cy.wait(500); // eslint-disable-line @finsit/cypress/no-unnecessary-waiting
   typeCode(`{${cmdPlus('alt+f')}}`);
   typeInSearchField(`${term}{enter}`);
   if (replaceWith) {
@@ -225,7 +221,7 @@ export const replaceInCode = (term, replaceWith) => {
  */
 export const jumpToLine = (line) => {
   // Wait necessary to ensure code pane is focussed
-  cy.wait(200); // eslint-disable-line @finsit/cypress/no-unnecessary-waiting
+  cy.wait(500); // eslint-disable-line @finsit/cypress/no-unnecessary-waiting
   typeCode(`{${cmdPlus('g')}}`);
   typeCode(`${line}{enter}`);
 };


### PR DESCRIPTION
Currently, Cypress tests in CI are unreliable and will only pass a slim majority of the time. This change adds some more time for new search-related shortcut tests to ensure Playroom has settled after shortcuts are triggered. This branch has passed Cypress in CI over 10 times and is proving more reliable.

* Increase wait times for "Find", "Find and replace" and "Jump to line" functions in Cypress tests
* Remove `force` from `typeInSearchField` function