### PR TITLE
Upgrade `lz-string` to version 1.5.0

### DIFF
--- a/.changeset/sweet-buses-taste.md
+++ b/.changeset/sweet-buses-taste.md
@@ -1,0 +1,5 @@
+---
+'playroom': patch
+---
+
+Update lz-string to 1.5.0, and removed unnecessary @types/lz-string

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/base64-url": "^2.2.0",
     "@types/codemirror": "^5.60.5",
     "@types/lodash": "^4.14.191",
+    "@types/lz-string": "^1.3.34",
     "@types/prettier": "^2.7.1",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
@@ -136,7 +137,6 @@
   },
   "packageManager": "pnpm@8.15.3",
   "volta": {
-    "node": "18.19.1",
-    "pnpm": "8.15.6"
+    "node": "18.19.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@types/base64-url": "^2.2.0",
     "@types/codemirror": "^5.60.5",
     "@types/lodash": "^4.14.191",
-    "@types/lz-string": "^1.3.34",
     "@types/prettier": "^2.7.1",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
@@ -88,7 +87,7 @@
     "intersection-observer": "^0.12.2",
     "localforage": "^1.10.0",
     "lodash": "^4.17.21",
-    "lz-string": "^1.4.4",
+    "lz-string": "^1.5.0",
     "memoize-one": "^6.0.0",
     "mini-css-extract-plugin": "^2.7.2",
     "parse-prop-types": "^0.3.0",
@@ -137,6 +136,7 @@
   },
   "packageManager": "pnpm@8.15.3",
   "volta": {
-    "node": "18.19.1"
+    "node": "18.19.1",
+    "pnpm": "8.15.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@types/base64-url": "^2.2.0",
     "@types/codemirror": "^5.60.5",
     "@types/lodash": "^4.14.191",
-    "@types/lz-string": "^1.3.34",
     "@types/prettier": "^2.7.1",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ dependencies:
   '@types/lodash':
     specifier: ^4.14.191
     version: 4.14.191
-  '@types/lz-string':
-    specifier: ^1.3.34
-    version: 1.3.34
   '@types/prettier':
     specifier: ^2.7.1
     version: 2.7.1
@@ -105,8 +102,8 @@ dependencies:
     specifier: ^4.17.21
     version: 4.17.21
   lz-string:
-    specifier: ^1.4.4
-    version: 1.4.4
+    specifier: ^1.5.0
+    version: 1.5.0
   memoize-one:
     specifier: ^6.0.0
     version: 6.0.0
@@ -2783,10 +2780,6 @@ packages:
 
   /@types/lodash@4.14.191:
     resolution: {integrity: sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==}
-    dev: false
-
-  /@types/lz-string@1.3.34:
-    resolution: {integrity: sha512-j6G1e8DULJx3ONf6NdR5JiR2ZY3K3PaaqiEuKYkLQO0Czfi1AzrtjfnfCROyWGeDd5IVMKCwsgSmMip9OWijow==}
     dev: false
 
   /@types/mime@1.3.5:
@@ -7309,8 +7302,8 @@ packages:
     dependencies:
       yallist: 4.0.0
 
-  /lz-string@1.4.4:
-    resolution: {integrity: sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==}
+  /lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
     dev: false
 


### PR DESCRIPTION
Upgraded `lz`string` to 1.5.0, which also removes the need for `@types/lz-string`