### PR TITLE
Fix centering of settings panel and toolbar icons

### DIFF
--- a/.changeset/strange-zoos-compare.md
+++ b/.changeset/strange-zoos-compare.md
@@ -2,4 +2,4 @@
 'playroom': patch
 ---
 
-Fix icon centering
+Fix Playroom UI icon centering

--- a/.changeset/strange-zoos-compare.md
+++ b/.changeset/strange-zoos-compare.md
@@ -1,0 +1,5 @@
+---
+'playroom': patch
+---
+
+Fix icon centering

--- a/src/Playroom/SettingsPanel/SettingsPanel.css.ts
+++ b/src/Playroom/SettingsPanel/SettingsPanel.css.ts
@@ -53,12 +53,6 @@ export const realRadio = style([
   },
 ]);
 
-export const labelText = sprinkles({
-  display: 'block',
-  position: 'relative',
-  zIndex: 1,
-});
-
 export const label = style([
   sprinkles({
     position: 'relative',

--- a/src/Playroom/SettingsPanel/SettingsPanel.tsx
+++ b/src/Playroom/SettingsPanel/SettingsPanel.tsx
@@ -117,9 +117,7 @@ export default React.memo(() => {
                   className={styles.label}
                   title={option}
                 >
-                  <span className={styles.labelText}>
-                    {positionIcon[option.toLowerCase() as EditorPosition]}
-                  </span>
+                  {positionIcon[option.toLowerCase() as EditorPosition]}
                 </label>
               </div>
             ))}
@@ -155,9 +153,7 @@ export default React.memo(() => {
                   className={styles.label}
                   title={option}
                 >
-                  <span className={styles.labelText}>
-                    {colorModeIcon[option.toLowerCase() as ColorScheme]}
-                  </span>
+                  {colorModeIcon[option.toLowerCase() as ColorScheme]}
                 </label>
               </div>
             ))}

--- a/src/Playroom/ToolbarItem/ToolbarItem.tsx
+++ b/src/Playroom/ToolbarItem/ToolbarItem.tsx
@@ -40,7 +40,7 @@ export default ({
       onClick();
     }}
   >
-    <span style={{ display: 'block', position: 'relative' }}>{children}</span>
+    {children}
     <span
       className={classnames(styles.indicator, {
         [styles.show]: showIndicator && !success,


### PR DESCRIPTION
The element wrapping these icons wasn't really doing anything, other than causing the icons to be laid out in flow layout, resulting in extra bottom padding because of line height. Rather than setting `line-height: 0` on the wrapping elements, I just removed them so the icons are now using flex, so they don't end up with the line height padding.

Before:
<img width="161" alt="before 1" src="https://github.com/seek-oss/playroom/assets/5663042/d11fae8b-129c-47ec-982d-3b3f365fb7d1">
<img width="96" alt="before 2" src="https://github.com/seek-oss/playroom/assets/5663042/86166f0b-0b15-4221-bd92-f0c3a5b4bc49">

After:
<img width="167" alt="after 1" src="https://github.com/seek-oss/playroom/assets/5663042/2a7c5cec-8868-40d6-b8b2-37d41d979e31">
<img width="116" alt="after 2" src="https://github.com/seek-oss/playroom/assets/5663042/1dfc6906-0755-4a3f-a0ff-33b1d5147d78">
