### PR TITLE
start: Disable webpack error overlay

### DIFF
--- a/.changeset/rich-geese-confess.md
+++ b/.changeset/rich-geese-confess.md
@@ -1,0 +1,8 @@
+---
+'playroom': patch
+---
+
+start: Disable webpack error overlay
+
+Prevent the default webpack dev server error overlay from blocking the preview frames in `start` mode.
+Playroom handles it's own errors, and this would block the preview frames and need to be dismissed manually.

--- a/.changeset/rich-geese-confess.md
+++ b/.changeset/rich-geese-confess.md
@@ -5,4 +5,4 @@
 start: Disable webpack error overlay
 
 Prevent the default webpack dev server error overlay from blocking the preview frames in `start` mode.
-Playroom handles it's own errors, and this would block the preview frames and need to be dismissed manually.
+Playroom handles its own errors, and this would block the preview frames and need to be dismissed manually.

--- a/lib/start.js
+++ b/lib/start.js
@@ -30,6 +30,9 @@ module.exports = async (config, callback) => {
       devMiddleware: {
         stats: false,
       },
+      client: {
+        overlay: false,
+      },
       compress: true,
       static: {
         watch: { ignored: /node_modules/ },


### PR DESCRIPTION
Prevent the default webpack dev server error overlay from blocking the preview frames in `start` mode.
Playroom handles it's own errors, and this would block the preview frames and need to be dismissed manually.