### PR TITLE
Save code editor size preference as percentage

### DIFF
--- a/.changeset/clever-keys-act.md
+++ b/.changeset/clever-keys-act.md
@@ -1,0 +1,6 @@
+---
+'playroom': minor
+---
+
+Save editor height and width preferences as a percentage of the viewport size, rather than a fixed pixel value.
+This prevents the editor from obscuring preview panels when toggling the browser tools on/off.

--- a/.changeset/clever-keys-act.md
+++ b/.changeset/clever-keys-act.md
@@ -3,4 +3,4 @@
 ---
 
 Save editor height and width preferences as a percentage of the viewport size, rather than a fixed pixel value.
-This prevents the editor from obscuring preview panels when toggling the browser tools on/off.
+This prevents the editor from obscuring preview panels when toggling the browser tools on/off or resizing the window.

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@types/react-dom": "^18.0.9",
     "@vanilla-extract/css": "^1.9.2",
     "@vanilla-extract/css-utils": "^0.1.3",
+    "@vanilla-extract/dynamic": "^2.1.2",
     "@vanilla-extract/sprinkles": "^1.5.1",
     "@vanilla-extract/webpack-plugin": "^2.3.6",
     "babel-loader": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ dependencies:
   '@vanilla-extract/css-utils':
     specifier: ^0.1.3
     version: 0.1.3
+  '@vanilla-extract/dynamic':
+    specifier: ^2.1.2
+    version: 2.1.2
   '@vanilla-extract/sprinkles':
     specifier: ^1.5.1
     version: 1.5.1(@vanilla-extract/css@1.14.1)
@@ -3141,6 +3144,12 @@ packages:
       outdent: 0.8.0
     dev: false
 
+  /@vanilla-extract/dynamic@2.1.2:
+    resolution: {integrity: sha512-9BGMciD8rO1hdSPIAh1ntsG4LPD3IYKhywR7VOmmz9OO4Lx1hlwkSg3E6X07ujFx7YuBfx0GDQnApG9ESHvB2A==}
+    dependencies:
+      '@vanilla-extract/private': 1.0.6
+    dev: false
+
   /@vanilla-extract/integration@7.1.0:
     resolution: {integrity: sha512-kCFn2IfnCHf4PCP538zBs5g6JJvqybJ4lU+ww2CeV/B2roze8drF7jVu2hDQUTtfiXgNe0Q3WpUfXdX27KFLsw==}
     dependencies:
@@ -3170,6 +3179,10 @@ packages:
 
   /@vanilla-extract/private@1.0.3:
     resolution: {integrity: sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ==}
+    dev: false
+
+  /@vanilla-extract/private@1.0.6:
+    resolution: {integrity: sha512-ytsG/JLweEjw7DBuZ/0JCN4WAQgM9erfSTdS1NQY778hFQSZ6cfCDEZZ0sgVm4k54uNz6ImKB33AYvSR//fjxw==}
     dev: false
 
   /@vanilla-extract/sprinkles@1.5.1(@vanilla-extract/css@1.14.1):

--- a/src/Playroom/Playroom.css.ts
+++ b/src/Playroom/Playroom.css.ts
@@ -49,7 +49,7 @@ export const previewContainerPosition = styleVariants({
   undocked: {},
 });
 
-export const resizeableContainer = style([
+export const resizableContainer = style([
   sprinkles({
     bottom: 0,
     right: 0,
@@ -59,34 +59,34 @@ export const resizeableContainer = style([
   }),
   // @ts-expect-error Shouldnt need to but types do not like `!important`
   {
-    position: 'absolute !important', // override re-resizeable's inline style
+    position: 'absolute !important', // override re-resizable's inline style
   },
 ]);
 
-export const resizeableContainer_isHidden = style({});
+export const resizableContainer_isHidden = style({});
 
-export const resizeableContainer_isRight = style([
+export const resizableContainer_isRight = style([
   sprinkles({
     top: 0,
   }),
   {
     maxWidth: '90vw',
     selectors: {
-      [`&${resizeableContainer_isHidden}`]: {
+      [`&${resizableContainer_isHidden}`]: {
         transform: 'translateX(100%)',
       },
     },
   },
 ]);
 
-export const resizeableContainer_isBottom = style([
+export const resizableContainer_isBottom = style([
   sprinkles({
     left: 0,
   }),
   {
     maxHeight: '90vh',
     selectors: {
-      [`&${resizeableContainer_isHidden}`]: {
+      [`&${resizableContainer_isHidden}`]: {
         transform: 'translateY(100%)',
       },
     },

--- a/src/Playroom/Playroom.css.ts
+++ b/src/Playroom/Playroom.css.ts
@@ -37,14 +37,14 @@ export const previewContainer = sprinkles({
   inset: 0,
 });
 
-export const editorSizePercentage = createVar();
+export const editorSize = createVar();
 
 export const previewContainerPosition = styleVariants({
   right: {
-    right: `max(${editorSizePercentage}, ${MIN_WIDTH}px)`,
+    right: `max(${editorSize}, ${MIN_WIDTH}px)`,
   },
   bottom: {
-    bottom: `max(${editorSizePercentage}, ${MIN_HEIGHT}px)`,
+    bottom: `max(${editorSize}, ${MIN_HEIGHT}px)`,
   },
   undocked: {},
 });

--- a/src/Playroom/Playroom.css.ts
+++ b/src/Playroom/Playroom.css.ts
@@ -1,7 +1,16 @@
-import { style, globalStyle } from '@vanilla-extract/css';
+import {
+  style,
+  globalStyle,
+  styleVariants,
+  createVar,
+} from '@vanilla-extract/css';
 import { sprinkles, colorPaletteVars } from './sprinkles.css';
 import { vars } from './vars.css';
 import { toolbarItemSize } from './ToolbarItem/ToolbarItem.css';
+import { toolbarItemCount, toolbarOpenSize } from './toolbarConstants';
+
+export const MIN_HEIGHT = toolbarItemSize * toolbarItemCount;
+export const MIN_WIDTH = toolbarOpenSize + toolbarItemSize + 80;
 
 globalStyle('html', {
   width: '100%',
@@ -26,6 +35,18 @@ export const root = sprinkles({
 export const previewContainer = sprinkles({
   position: 'absolute',
   inset: 0,
+});
+
+export const editorSizePercentage = createVar();
+
+export const previewContainerPosition = styleVariants({
+  right: {
+    right: `max(${editorSizePercentage}, ${MIN_WIDTH}px)`,
+  },
+  bottom: {
+    bottom: `max(${editorSizePercentage}, ${MIN_HEIGHT}px)`,
+  },
+  undocked: {},
 });
 
 export const resizeableContainer = style([

--- a/src/Playroom/Playroom.tsx
+++ b/src/Playroom/Playroom.tsx
@@ -21,7 +21,7 @@ import * as styles from './Playroom.css';
 import { Box } from './Box/Box';
 
 import { assignInlineVars } from '@vanilla-extract/dynamic';
-import { editorSize as editorSize } from './Playroom.css';
+import { editorSize } from './Playroom.css';
 
 const resizableConfig = (position: EditorPosition = 'bottom') => ({
   top: position === 'bottom',
@@ -135,7 +135,7 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
   const isVerticalEditor = editorPosition === 'right';
   const isHorizontalEditor = editorPosition === 'bottom';
   const sizeStyles = {
-    height: isHorizontalEditor ? editorHeight : 'auto', // issue in ff & safari when not a string
+    height: isHorizontalEditor ? editorHeight : 'auto',
     width: isVerticalEditor ? editorWidth : 'auto',
   };
   const editorContainer =
@@ -176,7 +176,6 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
         </Helmet>
       )}
       <Box
-        id="preview"
         className={[
           styles.previewContainer,
           editorHidden

--- a/src/Playroom/Playroom.tsx
+++ b/src/Playroom/Playroom.tsx
@@ -7,7 +7,7 @@ import Frames from './Frames/Frames';
 import { WindowPortal } from './WindowPortal';
 import type { Snippets } from '../../utils';
 import componentsToHints from '../utils/componentsToHints';
-import Toolbar, { toolbarItemCount } from './Toolbar/Toolbar';
+import Toolbar from './Toolbar/Toolbar';
 import ChevronIcon from './icons/ChevronIcon';
 import { StatusMessage } from './StatusMessage/StatusMessage';
 import {
@@ -15,14 +15,13 @@ import {
   type EditorPosition,
 } from '../StoreContext/StoreContext';
 
-const MIN_HEIGHT = toolbarItemSize * toolbarItemCount;
-const MIN_WIDTH = toolbarOpenSize + toolbarItemSize + 80;
-
 import { CodeEditor } from './CodeEditor/CodeEditor';
 
 import * as styles from './Playroom.css';
-import { toolbarOpenSize } from './Toolbar/Toolbar.css';
-import { toolbarItemSize } from './ToolbarItem/ToolbarItem.css';
+import { Box } from './Box/Box';
+
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+import { editorSizePercentage } from './Playroom.css';
 
 const resizableConfig = (position: EditorPosition = 'bottom') => ({
   top: position === 'bottom',
@@ -158,8 +157,8 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
         })}
         defaultSize={sizeStyles}
         size={sizeStyles}
-        minWidth={isVerticalEditor ? MIN_WIDTH : undefined}
-        minHeight={MIN_HEIGHT}
+        minWidth={isVerticalEditor ? styles.MIN_WIDTH : undefined}
+        minHeight={styles.MIN_HEIGHT}
         onResize={(_event, _direction, { offsetWidth, offsetHeight }) => {
           updateEditorSize({ isVerticalEditor, offsetWidth, offsetHeight });
         }}
@@ -176,17 +175,20 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
           <title>{displayedTitle}</title>
         </Helmet>
       )}
-      <div
-        className={styles.previewContainer}
-        style={
+      <Box
+        id="preview"
+        className={[
+          styles.previewContainer,
           editorHidden
             ? undefined
-            : {
-                right: { right: editorWidthPercentage },
-                bottom: { bottom: editorHeightPercentage },
-                undocked: undefined,
-              }[editorPosition]
-        }
+            : styles.previewContainerPosition[editorPosition],
+        ]}
+        style={assignInlineVars({
+          [editorSizePercentage]:
+            editorPosition === 'right'
+              ? editorWidthPercentage
+              : editorHeightPercentage,
+        })}
       >
         <Frames
           code={previewRenderCode || code}
@@ -215,7 +217,7 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
             />
           </button>
         </div>
-      </div>
+      </Box>
       {editorContainer}
     </div>
   );

--- a/src/Playroom/Playroom.tsx
+++ b/src/Playroom/Playroom.tsx
@@ -133,18 +133,11 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
     </Fragment>
   );
 
-  if (editorHeightPercentage < 0 || editorHeightPercentage > 100) {
-    throw new Error('editorHeightPercentage must be a value between 0 and 100');
-  }
-  if (editorWidthPercentage < 0 || editorWidthPercentage > 100) {
-    throw new Error('editorWidthPercentage must be a value between 0 and 100');
-  }
-
   const isVerticalEditor = editorPosition === 'right';
   const isHorizontalEditor = editorPosition === 'bottom';
   const sizeStyles = {
-    height: isHorizontalEditor ? `${editorHeightPercentage}%` : 'auto', // issue in ff & safari when not a string
-    width: isVerticalEditor ? `${editorWidthPercentage}%` : 'auto',
+    height: isHorizontalEditor ? editorHeightPercentage : 'auto', // issue in ff & safari when not a string
+    width: isVerticalEditor ? editorWidthPercentage : 'auto',
   };
   const editorContainer =
     editorPosition === 'undocked' ? (
@@ -189,8 +182,8 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
           editorHidden
             ? undefined
             : {
-                right: { right: `${editorWidthPercentage}%` },
-                bottom: { bottom: `${editorHeightPercentage}%` },
+                right: { right: editorWidthPercentage },
+                bottom: { bottom: editorHeightPercentage },
                 undocked: undefined,
               }[editorPosition]
         }

--- a/src/Playroom/Playroom.tsx
+++ b/src/Playroom/Playroom.tsx
@@ -71,8 +71,8 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
   const [
     {
       editorPosition,
-      editorHeight,
-      editorWidth,
+      editorHeightPercentage,
+      editorWidthPercentage,
       editorHidden,
       visibleThemes,
       visibleWidths,
@@ -133,11 +133,18 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
     </Fragment>
   );
 
+  if (editorHeightPercentage < 0 || editorHeightPercentage > 100) {
+    throw new Error('editorHeightPercentage must be a value between 0 and 100');
+  }
+  if (editorWidthPercentage < 0 || editorWidthPercentage > 100) {
+    throw new Error('editorWidthPercentage must be a value between 0 and 100');
+  }
+
   const isVerticalEditor = editorPosition === 'right';
   const isHorizontalEditor = editorPosition === 'bottom';
   const sizeStyles = {
-    height: isHorizontalEditor ? `${editorHeight}px` : 'auto', // issue in ff & safari when not a string
-    width: isVerticalEditor ? `${editorWidth}px` : 'auto',
+    height: isHorizontalEditor ? `${editorHeightPercentage}%` : 'auto', // issue in ff & safari when not a string
+    width: isVerticalEditor ? `${editorWidthPercentage}%` : 'auto',
   };
   const editorContainer =
     editorPosition === 'undocked' ? (
@@ -182,8 +189,8 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
           editorHidden
             ? undefined
             : {
-                right: { right: editorWidth },
-                bottom: { bottom: editorHeight },
+                right: { right: `${editorWidthPercentage}%` },
+                bottom: { bottom: `${editorHeightPercentage}%` },
                 undocked: undefined,
               }[editorPosition]
         }

--- a/src/Playroom/Playroom.tsx
+++ b/src/Playroom/Playroom.tsx
@@ -149,10 +149,10 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
       </WindowPortal>
     ) : (
       <Resizable
-        className={classnames(styles.resizeableContainer, {
-          [styles.resizeableContainer_isRight]: isVerticalEditor,
-          [styles.resizeableContainer_isBottom]: isHorizontalEditor,
-          [styles.resizeableContainer_isHidden]: editorHidden,
+        className={classnames(styles.resizableContainer, {
+          [styles.resizableContainer_isRight]: isVerticalEditor,
+          [styles.resizableContainer_isBottom]: isHorizontalEditor,
+          [styles.resizableContainer_isHidden]: editorHidden,
         })}
         defaultSize={sizeStyles}
         size={sizeStyles}

--- a/src/Playroom/Playroom.tsx
+++ b/src/Playroom/Playroom.tsx
@@ -21,7 +21,6 @@ import * as styles from './Playroom.css';
 import { Box } from './Box/Box';
 
 import { assignInlineVars } from '@vanilla-extract/dynamic';
-import { editorSize } from './Playroom.css';
 
 const resizableConfig = (position: EditorPosition = 'bottom') => ({
   top: position === 'bottom',
@@ -183,7 +182,8 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
             : styles.previewContainerPosition[editorPosition],
         ]}
         style={assignInlineVars({
-          [editorSize]: editorPosition === 'right' ? editorWidth : editorHeight,
+          [styles.editorSize]:
+            editorPosition === 'right' ? editorWidth : editorHeight,
         })}
       >
         <Frames

--- a/src/Playroom/Playroom.tsx
+++ b/src/Playroom/Playroom.tsx
@@ -21,7 +21,7 @@ import * as styles from './Playroom.css';
 import { Box } from './Box/Box';
 
 import { assignInlineVars } from '@vanilla-extract/dynamic';
-import { editorSizePercentage } from './Playroom.css';
+import { editorSize as editorSize } from './Playroom.css';
 
 const resizableConfig = (position: EditorPosition = 'bottom') => ({
   top: position === 'bottom',
@@ -70,8 +70,8 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
   const [
     {
       editorPosition,
-      editorHeightPercentage,
-      editorWidthPercentage,
+      editorHeight,
+      editorWidth,
       editorHidden,
       visibleThemes,
       visibleWidths,
@@ -135,8 +135,8 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
   const isVerticalEditor = editorPosition === 'right';
   const isHorizontalEditor = editorPosition === 'bottom';
   const sizeStyles = {
-    height: isHorizontalEditor ? editorHeightPercentage : 'auto', // issue in ff & safari when not a string
-    width: isVerticalEditor ? editorWidthPercentage : 'auto',
+    height: isHorizontalEditor ? editorHeight : 'auto', // issue in ff & safari when not a string
+    width: isVerticalEditor ? editorWidth : 'auto',
   };
   const editorContainer =
     editorPosition === 'undocked' ? (
@@ -184,10 +184,7 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
             : styles.previewContainerPosition[editorPosition],
         ]}
         style={assignInlineVars({
-          [editorSizePercentage]:
-            editorPosition === 'right'
-              ? editorWidthPercentage
-              : editorHeightPercentage,
+          [editorSize]: editorPosition === 'right' ? editorWidth : editorHeight,
         })}
       >
         <Frames

--- a/src/Playroom/Toolbar/Toolbar.css.ts
+++ b/src/Playroom/Toolbar/Toolbar.css.ts
@@ -2,8 +2,8 @@ import { calc } from '@vanilla-extract/css-utils';
 import { style } from '@vanilla-extract/css';
 import { sprinkles, colorPaletteVars } from '../sprinkles.css';
 import { toolbarItemSize } from '../ToolbarItem/ToolbarItem.css';
+import { toolbarOpenSize } from '../toolbarConstants';
 
-export const toolbarOpenSize = 320;
 const toolbarBorderThickness = '1px';
 
 export const isOpen = style({});

--- a/src/Playroom/Toolbar/Toolbar.tsx
+++ b/src/Playroom/Toolbar/Toolbar.tsx
@@ -25,7 +25,6 @@ interface Props {
   snippets: PlayroomProps['snippets'];
 }
 
-export const toolbarItemCount = 5;
 const ANIMATION_TIMEOUT = 300;
 
 export default ({ themes: allThemes, widths: allWidths, snippets }: Props) => {

--- a/src/Playroom/toolbarConstants.ts
+++ b/src/Playroom/toolbarConstants.ts
@@ -1,0 +1,5 @@
+// Isolating these constants from React files so they can be used in Vanilla Extract styles
+
+export const toolbarItemCount = 5;
+export const toolbarItemSize = 60;
+export const toolbarOpenSize = 320;

--- a/src/StoreContext/StoreContext.tsx
+++ b/src/StoreContext/StoreContext.tsx
@@ -481,6 +481,8 @@ export const StoreProvider = ({
     Promise.all([
       store.getItem<string>('code'),
       store.getItem<EditorPosition>('editorPosition'),
+      store.getItem<number>('editorHeight'), // Deprecated
+      store.getItem<number>('editorWidth'), // Deprecated
       store.getItem<string>('editorHeightPercentage'),
       store.getItem<string>('editorWidthPercentage'),
       store.getItem<number[]>('visibleWidths'),
@@ -490,27 +492,37 @@ export const StoreProvider = ({
       ([
         storedCode,
         storedPosition,
-        storedHeight,
-        storedWidth,
+        storedHeight, // Deprecated
+        storedWidth, // Deprecated
+        storedHeightPercentage,
+        storedWidthPercentage,
         storedVisibleWidths,
         storedVisibleThemes,
         storedColorScheme,
       ]) => {
         const code = codeFromQuery || storedCode || exampleCode;
         const editorPosition = storedPosition;
+
         const editorHeightPercentage =
-          storedHeight || defaultEditorSizePercentage;
+          storedHeightPercentage ||
+          (storedHeight ? `${storedHeight}px` : null) ||
+          defaultEditorSizePercentage;
+
         const editorWidthPercentage =
-          storedWidth || defaultEditorSizePercentage;
+          storedWidthPercentage ||
+          (storedWidth ? `${storedWidth}px` : null) ||
+          defaultEditorSizePercentage;
         const visibleWidths =
           widthsFromQuery ||
           storedVisibleWidths ||
           playroomConfig?.defaultVisibleWidths;
+
         const visibleThemes =
           hasThemesConfigured &&
           (themesFromQuery ||
             storedVisibleThemes ||
             playroomConfig?.defaultVisibleThemes);
+
         const colorScheme = storedColorScheme;
 
         dispatch({

--- a/src/StoreContext/StoreContext.tsx
+++ b/src/StoreContext/StoreContext.tsx
@@ -515,10 +515,8 @@ export const StoreProvider = ({
           payload: {
             ...(code ? { code } : {}),
             ...(editorPosition ? { editorPosition } : {}),
-            ...(editorHeightPercentage
-              ? { editorHeightPercentage }
-              : undefined),
-            ...(editorWidthPercentage ? { editorWidthPercentage } : undefined),
+            ...(editorHeightPercentage ? { editorHeightPercentage } : {}),
+            ...(editorWidthPercentage ? { editorWidthPercentage } : {}),
             ...(visibleThemes ? { visibleThemes } : {}),
             ...(visibleWidths ? { visibleWidths } : {}),
             ...(colorScheme ? { colorScheme } : {}),

--- a/src/StoreContext/StoreContext.tsx
+++ b/src/StoreContext/StoreContext.tsx
@@ -43,14 +43,16 @@ function convertAndStoreSizeAsPercentage(
 ): string {
   const viewportSize =
     mode === 'height' ? window.innerHeight : window.innerWidth;
-  const sizePercentage = `${Math.round((size / viewportSize) * 100)}%`;
+
+  const sizePercentage = (size / viewportSize) * 100;
+  const roundedSizePercentage = `${Math.round(sizePercentage)}%`;
 
   store.setItem(
     `${mode === 'height' ? 'editorHeight' : 'editorWidth'}`,
-    sizePercentage
+    roundedSizePercentage
   );
 
-  return sizePercentage;
+  return `${sizePercentage}%`;
 }
 
 interface DebounceUpdateUrl {

--- a/src/StoreContext/StoreContext.tsx
+++ b/src/StoreContext/StoreContext.tsx
@@ -65,8 +65,8 @@ interface State {
   cursorPosition: CursorPosition;
   editorHidden: boolean;
   editorPosition: EditorPosition;
-  editorHeight: number;
-  editorWidth: number;
+  editorHeightPercentage: number;
+  editorWidthPercentage: number;
   statusMessage?: StatusMessage;
   visibleThemes?: string[];
   visibleWidths?: number[];
@@ -328,21 +328,25 @@ const createReducer =
 
       case 'updateEditorHeight': {
         const { size } = action.payload;
-        store.setItem('editorHeight', size);
+        const viewportHeight = window.innerHeight;
+        const heightPercentage = (size / viewportHeight) * 100;
+        store.setItem('editorHeightPercentage', heightPercentage);
 
         return {
           ...state,
-          editorHeight: size,
+          editorHeightPercentage: heightPercentage,
         };
       }
 
       case 'updateEditorWidth': {
         const { size } = action.payload;
-        store.setItem('editorWidth', size);
+        const viewportWidth = window.innerWidth;
+        const widthPercentage = (size / viewportWidth) * 100;
+        store.setItem('editorWidthPercentage', widthPercentage);
 
         return {
           ...state,
-          editorWidth: size,
+          editorWidthPercentage: widthPercentage,
         };
       }
 
@@ -408,8 +412,8 @@ const initialState: State = {
   cursorPosition: { line: 0, ch: 0 },
   editorHidden: false,
   editorPosition: defaultPosition,
-  editorHeight: 300,
-  editorWidth: 360,
+  editorHeightPercentage: 40,
+  editorWidthPercentage: 40,
   ready: false,
   colorScheme: 'light',
 };
@@ -473,8 +477,8 @@ export const StoreProvider = ({
     Promise.all([
       store.getItem<string>('code'),
       store.getItem<EditorPosition>('editorPosition'),
-      store.getItem<number>('editorHeight'),
-      store.getItem<number>('editorWidth'),
+      store.getItem<number>('editorHeightPercentage'),
+      store.getItem<number>('editorWidthPercentage'),
       store.getItem<number[]>('visibleWidths'),
       store.getItem<string[]>('visibleThemes'),
       store.getItem<ColorScheme>('colorScheme'),
@@ -490,8 +494,8 @@ export const StoreProvider = ({
       ]) => {
         const code = codeFromQuery || storedCode || exampleCode;
         const editorPosition = storedPosition;
-        const editorHeight = storedHeight;
-        const editorWidth = storedWidth;
+        const editorHeightPercentage = storedHeight;
+        const editorWidthPercentage = storedWidth;
         const visibleWidths =
           widthsFromQuery ||
           storedVisibleWidths ||
@@ -508,8 +512,8 @@ export const StoreProvider = ({
           payload: {
             ...(code ? { code } : {}),
             ...(editorPosition ? { editorPosition } : {}),
-            ...(editorHeight ? { editorHeight } : {}),
-            ...(editorWidth ? { editorWidth } : {}),
+            ...(editorHeightPercentage ? { editorHeightPercentage } : {}),
+            ...(editorWidthPercentage ? { editorWidthPercentage } : {}),
             ...(visibleThemes ? { visibleThemes } : {}),
             ...(visibleWidths ? { visibleWidths } : {}),
             ...(colorScheme ? { colorScheme } : {}),

--- a/src/StoreContext/StoreContext.tsx
+++ b/src/StoreContext/StoreContext.tsx
@@ -37,19 +37,6 @@ const applyColorScheme = (colorScheme: Exclude<ColorScheme, 'system'>) => {
   ]('data-playroom-dark', '');
 };
 
-function getSizeAsPercentage(
-  mode: 'height' | 'width',
-  size: string | undefined
-): string | undefined {
-  if (!size || !size.endsWith('px')) {
-    return;
-  }
-
-  const storedSizeAsNumber = parseInt(size.split('px')[0], 10);
-
-  return convertAndStoreSizeAsPercentage(mode, storedSizeAsNumber);
-}
-
 function convertAndStoreSizeAsPercentage(
   mode: 'height' | 'width',
   size: number
@@ -158,17 +145,9 @@ const createReducer =
   (state: State, action: Action): State => {
     switch (action.type) {
       case 'initialLoad': {
-        const { editorHeight, editorWidth } = action.payload;
-
-        // If the stored size is in pixels, convert it to a percentage
-        const updatedEditorWidth = getSizeAsPercentage('width', editorWidth);
-        const updatedEditorHeight = getSizeAsPercentage('height', editorHeight);
-
         return {
           ...state,
           ...action.payload,
-          editorWidth: updatedEditorWidth || state.editorWidth,
-          editorHeight: updatedEditorHeight || state.editorHeight,
         };
       }
 
@@ -538,12 +517,12 @@ export const StoreProvider = ({
 
         const editorHeight =
           (typeof storedHeight === 'number'
-            ? `${storedHeight}px`
+            ? convertAndStoreSizeAsPercentage('height', storedHeight)
             : storedHeight) || defaultEditorSize;
 
         const editorWidth =
           (typeof storedWidth === 'number'
-            ? `${storedWidth}px`
+            ? convertAndStoreSizeAsPercentage('width', storedWidth)
             : storedWidth) || defaultEditorSize;
 
         const visibleWidths =

--- a/src/StoreContext/StoreContext.tsx
+++ b/src/StoreContext/StoreContext.tsx
@@ -25,6 +25,7 @@ const store = localforage.createInstance({
   version: 1,
 });
 
+const defaultEditorSizePercentage = '40%';
 const defaultPosition = 'bottom';
 
 export type EditorPosition = 'bottom' | 'right' | 'undocked';
@@ -415,8 +416,8 @@ const initialState: State = {
   cursorPosition: { line: 0, ch: 0 },
   editorHidden: false,
   editorPosition: defaultPosition,
-  editorHeightPercentage: '40%',
-  editorWidthPercentage: '40%',
+  editorHeightPercentage: defaultEditorSizePercentage,
+  editorWidthPercentage: defaultEditorSizePercentage,
   ready: false,
   colorScheme: 'light',
 };
@@ -497,8 +498,10 @@ export const StoreProvider = ({
       ]) => {
         const code = codeFromQuery || storedCode || exampleCode;
         const editorPosition = storedPosition;
-        const editorHeightPercentage = storedHeight;
-        const editorWidthPercentage = storedWidth;
+        const editorHeightPercentage =
+          storedHeight || defaultEditorSizePercentage;
+        const editorWidthPercentage =
+          storedWidth || defaultEditorSizePercentage;
         const visibleWidths =
           widthsFromQuery ||
           storedVisibleWidths ||

--- a/src/StoreContext/StoreContext.tsx
+++ b/src/StoreContext/StoreContext.tsx
@@ -65,8 +65,8 @@ interface State {
   cursorPosition: CursorPosition;
   editorHidden: boolean;
   editorPosition: EditorPosition;
-  editorHeightPercentage: number;
-  editorWidthPercentage: number;
+  editorHeightPercentage: string;
+  editorWidthPercentage: string;
   statusMessage?: StatusMessage;
   visibleThemes?: string[];
   visibleWidths?: number[];
@@ -329,7 +329,10 @@ const createReducer =
       case 'updateEditorHeight': {
         const { size } = action.payload;
         const viewportHeight = window.innerHeight;
-        const heightPercentage = (size / viewportHeight) * 100;
+        const heightPercentage = `${Math.round(
+          (size / viewportHeight) * 100
+        )}%`;
+
         store.setItem('editorHeightPercentage', heightPercentage);
 
         return {
@@ -341,7 +344,7 @@ const createReducer =
       case 'updateEditorWidth': {
         const { size } = action.payload;
         const viewportWidth = window.innerWidth;
-        const widthPercentage = (size / viewportWidth) * 100;
+        const widthPercentage = `${Math.round((size / viewportWidth) * 100)}%`;
         store.setItem('editorWidthPercentage', widthPercentage);
 
         return {
@@ -412,8 +415,8 @@ const initialState: State = {
   cursorPosition: { line: 0, ch: 0 },
   editorHidden: false,
   editorPosition: defaultPosition,
-  editorHeightPercentage: 40,
-  editorWidthPercentage: 40,
+  editorHeightPercentage: '40%',
+  editorWidthPercentage: '40%',
   ready: false,
   colorScheme: 'light',
 };
@@ -477,8 +480,8 @@ export const StoreProvider = ({
     Promise.all([
       store.getItem<string>('code'),
       store.getItem<EditorPosition>('editorPosition'),
-      store.getItem<number>('editorHeightPercentage'),
-      store.getItem<number>('editorWidthPercentage'),
+      store.getItem<string>('editorHeightPercentage'),
+      store.getItem<string>('editorWidthPercentage'),
       store.getItem<number[]>('visibleWidths'),
       store.getItem<string[]>('visibleThemes'),
       store.getItem<ColorScheme>('colorScheme'),
@@ -512,8 +515,10 @@ export const StoreProvider = ({
           payload: {
             ...(code ? { code } : {}),
             ...(editorPosition ? { editorPosition } : {}),
-            ...(editorHeightPercentage ? { editorHeightPercentage } : {}),
-            ...(editorWidthPercentage ? { editorWidthPercentage } : {}),
+            ...(editorHeightPercentage
+              ? { editorHeightPercentage }
+              : undefined),
+            ...(editorWidthPercentage ? { editorWidthPercentage } : undefined),
             ...(visibleThemes ? { visibleThemes } : {}),
             ...(visibleWidths ? { visibleWidths } : {}),
             ...(colorScheme ? { colorScheme } : {}),


### PR DESCRIPTION
See changeset.

Setting the defaults to 40% as these look pretty good even at smaller screen sizes, but open to suggestions if this should be different.