### PR TITLE
Provide explicit port for all projects

### DIFF
--- a/cypress/projects/basic/playroom.config.js
+++ b/cypress/projects/basic/playroom.config.js
@@ -4,5 +4,6 @@ module.exports = {
   snippets: './snippets',
   outputPath: './dist',
   openBrowser: false,
+  port: 9000,
   storageKey: 'playroom-example-basic',
 };

--- a/cypress/projects/typescript/playroom.config.js
+++ b/cypress/projects/typescript/playroom.config.js
@@ -3,6 +3,7 @@ module.exports = {
   snippets: './snippets.ts',
   outputPath: './dist',
   openBrowser: false,
+  port: 9002,
   storageKey: 'playroom-example-typescript',
   webpackConfig: () => ({
     module: {


### PR DESCRIPTION
Ensure both `basic` and `typescript` projects have an explicit port, similar to `themed`.

This change prevents some issues running the `typescript` project locally, with the port not falling back to the expected value.

Adding the expected port to the `basic` project as well for explicitness and consistency.