### PR TITLE
Tighten webpack rule merge rules to prevent clashes

### DIFF
--- a/.changeset/nasty-brooms-brush.md
+++ b/.changeset/nasty-brooms-brush.md
@@ -2,4 +2,6 @@
 'playroom': patch
 ---
 
-Tighten webpack config merge rules to prevent clashes
+Tighten webpack config merge rules to prevent replacing playroom webpack config with user-provided webpack config
+
+When merging user-provided webpack config, a module rule's `test`, `include` and `exclude` property will all be compared.

--- a/.changeset/nasty-brooms-brush.md
+++ b/.changeset/nasty-brooms-brush.md
@@ -2,4 +2,4 @@
 'playroom': patch
 ---
 
-Tighten webpack rule merge rules to prevent clashes
+Tighten webpack config merge rules to prevent clashes

--- a/.changeset/nasty-brooms-brush.md
+++ b/.changeset/nasty-brooms-brush.md
@@ -1,0 +1,5 @@
+---
+'playroom': patch
+---
+
+Tighten webpack rule merge rules to prevent clashes

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -205,6 +205,8 @@ module.exports = async (playroomConfig, options) => {
     module: {
       rules: {
         test: 'match',
+        include: 'match',
+        exclude: 'match',
         use: 'replace',
       },
     },


### PR DESCRIPTION
## Problem

Playroom has its own webpack config, and has the ability for consumers to provide their own, which are both merged to create a single webpack config.

The merge matches rules, i.e. determines their uniqueness only by comparing the `test` property of a rule. So if a consumer tries to add a module rule with the same test as one of playroom's own configs, they will be treated as equal and thus one will override the other.

e.g.
```ts
const playroomConfig = {
  {
    test: /\.css$/,
    include: path.dirname(require.resolve('codemirror/package.json')),
    use: [MiniCssExtractPlugin.loader, require.resolve('css-loader')],
  },
}

const consumerConfig = {
  {
    test: /\.css$/,
    include: /my_files/,
    use: "style-loader",
  },
}
``` 

In the above example, both rules are considered equal, so one will take precedence, leading to a misconfiguration.

## Solution
Include the `include` and `exclude` properties in the comparison too, to ensure a rule is uniquely identified by all 3 properties `test`, `include` and `exclude`.