### PR TITLE
Restrict VanillaExtract plugin to playroom's source `.css.ts` files only

### DIFF
--- a/.changeset/slow-plums-bake.md
+++ b/.changeset/slow-plums-bake.md
@@ -1,0 +1,5 @@
+---
+'playroom': patch
+---
+
+Restrict VanillaExtract plugin to playroom's source `.css.ts` files only

--- a/.changeset/slow-plums-bake.md
+++ b/.changeset/slow-plums-bake.md
@@ -2,4 +2,4 @@
 'playroom': patch
 ---
 
-Restrict VanillaExtract plugin to playroom's source `.css.ts` files only
+Restrict `playroom`'s Vanilla Extract plugin to only process playroom's `.css.ts` files

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -185,9 +185,7 @@ module.exports = async (playroomConfig, options) => {
           // Only apply VanillaExtract plugin to playroom's source `.css.ts` files
           return (
             /\.css\.ts$/i.test(filePath) &&
-            includePaths.some((includePath) =>
-              filePath.startsWith(includePath)
-            )
+            includePaths.some((includePath) => filePath.startsWith(includePath))
           );
         },
       }),

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -185,9 +185,8 @@ module.exports = async (playroomConfig, options) => {
           // Only apply VanillaExtract plugin to playroom's source `.css.ts` files
           return (
             /\.css\.ts$/i.test(filePath) &&
-            includePaths.some((playroomPath) =>
-              filePath.startsWith(playroomPath)
-            )
+            includePaths.some(filePath.startsWith)
+
           );
         },
       }),

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -185,7 +185,9 @@ module.exports = async (playroomConfig, options) => {
           // Only apply VanillaExtract plugin to playroom's source `.css.ts` files
           return (
             /\.css\.ts$/i.test(filePath) &&
-            includePaths.some(filePath.startsWith)
+            includePaths.some((playroomPath) =>
+              filePath.startsWith(playroomPath)
+            )
           );
         },
       }),

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -186,7 +186,6 @@ module.exports = async (playroomConfig, options) => {
           return (
             /\.css\.ts$/i.test(filePath) &&
             includePaths.some(filePath.startsWith)
-
           );
         },
       }),

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -185,7 +185,9 @@ module.exports = async (playroomConfig, options) => {
           // Only apply VanillaExtract plugin to playroom's source `.css.ts` files
           return (
             /\.css\.ts$/i.test(filePath) &&
-            includePaths.some((playRoomPath) => filePath.includes(playRoomPath))
+            includePaths.some((playroomPath) =>
+              filePath.startsWith(playroomPath)
+            )
           );
         },
       }),

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -185,8 +185,8 @@ module.exports = async (playroomConfig, options) => {
           // Only apply VanillaExtract plugin to playroom's source `.css.ts` files
           return (
             /\.css\.ts$/i.test(filePath) &&
-            includePaths.some((playroomPath) =>
-              filePath.startsWith(playroomPath)
+            includePaths.some((includePath) =>
+              filePath.startsWith(includePath)
             )
           );
         },

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -180,7 +180,15 @@ module.exports = async (playroomConfig, options) => {
         filename: 'preview/index.html',
         publicPath: '../',
       }),
-      new VanillaExtractPlugin(),
+      new VanillaExtractPlugin({
+        test: (filePath) => {
+          // Only apply VanillaExtract plugin to playroom's source `.css.ts` files
+          return (
+            /\.css\.ts$/i.test(filePath) &&
+            includePaths.some((playRoomPath) => filePath.includes(playRoomPath))
+          );
+        },
+      }),
       new MiniCssExtractPlugin({ ignoreOrder: true }),
       ...(options.production ? [] : [new FriendlyErrorsWebpackPlugin()]),
       // If using a version of React earlier than 18, ignore the


### PR DESCRIPTION
## Problem

Playroom uses `VanillaExtract` to extract and process CSS files, specifically `.css.ts` files. While the webpack loader rule correctly limits the scope of this loader on playroom's own source code, the plugin itself isn't scoped, and as such, it sends up processing every single `.css.[t|j]s` file it can find, including those from the consumer's codebase, `node_modules`, etc..

This problematic, and leads to a whole range of issues, making Playroom unusable if your UI Library has `.css.[j|t]s` files, or even if one of your dependencies has it.

> I haven't found any mention of the plugin being scoped to the entire project by default, as their [documentation](https://vanilla-extract.style/documentation/integrations/webpack/#configuration) page is non-exhaustive, however I can confirm this to be the case.

## Solution

Correctly scope the plugin to Playroom's own `.css.ts` files only.