### PR TITLE
Revert "Tighten webpack rule merge rules to prevent clashes (#376)"

### DIFF
--- a/.changeset/nasty-brooms-brush.md
+++ b/.changeset/nasty-brooms-brush.md
@@ -1,7 +1,0 @@
----
-'playroom': patch
----
-
-Tighten webpack config merge rules to prevent replacing playroom webpack config with user-provided webpack config
-
-When merging user-provided webpack config, a module rule's `test`, `include` and `exclude` property will all be compared.

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -205,8 +205,6 @@ module.exports = async (playroomConfig, options) => {
     module: {
       rules: {
         test: 'match',
-        include: 'match',
-        exclude: 'match',
         use: 'replace',
       },
     },


### PR DESCRIPTION
Revert #376. This was causing issues with our internal usage of playroom. We rely on overriding playroom's `.css` file loading, but making the webpack merge rules stricter has made it impractical to override this rule (it required explicitly targeting codemirror within playroom's node modules). See https://github.com/seek-oss/playroom/pull/376#issuecomment-2481898315 for further discussion.