### PR TITLE
Replace `polished` dependency with CSS relative color syntax and `color-mix`

### DIFF
--- a/.changeset/few-coats-smash.md
+++ b/.changeset/few-coats-smash.md
@@ -1,0 +1,5 @@
+---
+'playroom': patch
+---
+
+Replace `polished` dependency with CSS relative color syntax and `color-mix`

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "memoize-one": "^6.0.0",
     "mini-css-extract-plugin": "^2.7.2",
     "parse-prop-types": "^0.3.0",
-    "polished": "^4.2.2",
     "portfinder": "^1.0.32",
     "prettier": "^2.8.1",
     "prop-types": "^15.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,9 +110,6 @@ dependencies:
   parse-prop-types:
     specifier: ^0.3.0
     version: 0.3.0(prop-types@15.8.1)
-  polished:
-    specifier: ^4.2.2
-    version: 4.2.2
   portfinder:
     specifier: ^1.0.32
     version: 1.0.32
@@ -8282,13 +8279,6 @@ packages:
       jsonc-parser: 3.2.1
       mlly: 1.5.0
       pathe: 1.1.2
-    dev: false
-
-  /polished@4.2.2:
-    resolution: {integrity: sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      '@babel/runtime': 7.20.6
     dev: false
 
   /portfinder@1.0.32:

--- a/src/Playroom/palettes.ts
+++ b/src/Playroom/palettes.ts
@@ -42,7 +42,7 @@ export const light = {
     positive: originalPalette.green2,
   },
   background: {
-    transparent: 'rgba(0, 0, 0, .05)',
+    transparent: 'rgb(0, 0, 0, .05)',
     accent: originalPalette.blue2,
     positive: originalPalette.green1,
     critical: originalPalette.red1,
@@ -56,7 +56,7 @@ export const light = {
     standard: originalPalette.gray2,
   },
   shadows: {
-    small: '0 2px 8px rgba(18, 21, 26, 0.3)',
+    small: '0 2px 8px rgb(18, 21, 26, 0.3)',
     focus: `0 0 0 5px ${originalPalette.blue0}`,
   },
 };
@@ -144,7 +144,7 @@ export const dark = {
     positive: seekPalette.mint[500],
   },
   background: {
-    transparent: 'rgba(255, 255, 255, .07)',
+    transparent: 'rgb(255, 255, 255, .07)',
     accent: seekPalette.blue[500],
     positive: mix(0.6, seekPalette.grey[900], seekPalette.mint[500]),
     critical: mix(0.7, seekPalette.grey[900], seekPalette.red[600]),

--- a/src/Playroom/palettes.ts
+++ b/src/Playroom/palettes.ts
@@ -1,5 +1,3 @@
-import { transparentize, mix, darken } from 'polished';
-
 const originalPalette = {
   blue0: '#e5f3ff',
   blue1: '#0088ff',
@@ -21,6 +19,35 @@ const originalPalette = {
   gray6: '#1e1e1e',
   black: '#000',
 };
+
+const guard = (amount: number) => {
+  if (amount > 1 || amount < 0) {
+    throw new Error('Amount must be between 0 and 1 inclusive');
+  }
+
+  return amount;
+};
+
+/**
+ * Implementation of `transparentize` from polished but using native CSS
+ * @see https://polished.js.org/docs/#transparentize
+ */
+const transparentize = (amount: number, color: string) =>
+  `rgb(from ${color} r g b / calc(alpha - ${guard(amount)}))`;
+
+/**
+ * Implementation of `darken` from polished but using native CSS
+ * @see https://polished.js.org/docs/#darken
+ */
+const darken = (amount: number, color: string) =>
+  `hsl(from ${color} h s calc(l - ${guard(amount) * 100}))`;
+
+/**
+ * Implementation of `mix` from polished but using native CSS
+ * @see https://polished.js.org/docs/#mix
+ */
+const mix = (amount: number, color1: string, color2: string) =>
+  `color-mix(in srgb, ${color1} ${guard(amount) * 100}%, ${color2})`;
 
 export const light = {
   code: {

--- a/src/Playroom/palettes.ts
+++ b/src/Playroom/palettes.ts
@@ -29,21 +29,30 @@ const guard = (amount: number) => {
 };
 
 /**
- * Implementation of `transparentize` from polished but using native CSS
+ * Subtracts `amount` from the alpha channel of `color`.
+ * Amount must be between 0 and 1 inclusive.
+ *
+ * Similar to `transparentize` from polished but uses CSS
  * @see https://polished.js.org/docs/#transparentize
  */
 const transparentize = (amount: number, color: string) =>
   `rgb(from ${color} r g b / calc(alpha - ${guard(amount)}))`;
 
 /**
- * Implementation of `darken` from polished but using native CSS
+ * Subtracts `amount` from the lightness of `color`.
+ * Amount must be between 0 and 1 inclusive.
+ *
+ * Similar to `darken` from polished but uses CSS
  * @see https://polished.js.org/docs/#darken
  */
 const darken = (amount: number, color: string) =>
   `hsl(from ${color} h s calc(l - ${guard(amount) * 100}))`;
 
 /**
- * Implementation of `mix` from polished but using native CSS
+ * Mixes `amount` of `color1` into `color2`.
+ * Amount must be between 0 and 1 inclusive.
+ *
+ * Similar to `mix` from polished but uses CSS
  * @see https://polished.js.org/docs/#mix
  */
 const mix = (amount: number, color1: string, color2: string) =>


### PR DESCRIPTION
Since the release of Safari 18, [relative color syntax](https://caniuse.com/?search=relative%20color) and [`color-mix`](https://caniuse.com/?search=color-mix) have adequate browser support and should be bug-free. This means we can safely replace `polished` with native CSS.

`polished` was only used at build-time, so this doesn't affect bundle size at all.

I checked all the colors affected by these changes. In most cases, the colors are identical (when converted to `rgb`), with a few having slightly different values, e.g. the blue channel increases by 1. I think this is acceptable.

Additionally, usage of `rgba` was replaced with `rgb` as `rgba` is considered legacy and `rgb` is [recommended](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb#:~:text=it%20is%20recommended%20to%20use%20rgb()) over it.