### PR TITLE
Ensure favicon is displayed on Preview links

### DIFF
--- a/.changeset/clean-pets-push.md
+++ b/.changeset/clean-pets-push.md
@@ -1,0 +1,5 @@
+---
+'playroom': patch
+---
+
+Ensure favicon is displayed on Preview links.

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -178,6 +178,7 @@ module.exports = async (playroomConfig, options) => {
         chunksSortMode: 'none',
         chunks: ['preview'],
         filename: 'preview/index.html',
+        favicon: path.join(__dirname, '../images/favicon.png'),
         publicPath: '../',
       }),
       new VanillaExtractPlugin({

--- a/src/preview.js
+++ b/src/preview.js
@@ -1,8 +1,21 @@
 import { renderElement } from './render';
 import Preview from './Playroom/Preview';
+import faviconPath from '../images/favicon.png';
+import faviconInvertedPath from '../images/favicon-inverted.png';
 
 const outlet = document.createElement('div');
 document.body.appendChild(outlet);
+
+const selectedElement = document.head.querySelector('link[rel="icon"]');
+const favicon = window.matchMedia('(prefers-color-scheme: dark)').matches
+  ? faviconInvertedPath
+  : faviconPath;
+
+const formattedFavicon = `../${favicon}`;
+
+if (selectedElement) {
+  selectedElement.setAttribute('href', formattedFavicon);
+}
 
 const renderPreview = ({
   themes = require('./themes'),


### PR DESCRIPTION
Making this change to improve tab management with preview links, and as an additional security measure to differentiate Playroom Previews/prototypes from genuine sites.