### PR TITLE
Remove keybinding for copying Playroom link to clipboard

### DIFF
--- a/.changeset/small-rules-bake.md
+++ b/.changeset/small-rules-bake.md
@@ -1,0 +1,5 @@
+---
+'playroom': minor
+---
+
+Remove keybinding for copying Playroom link to clipboard.

--- a/src/Playroom/CodeEditor/CodeEditor.tsx
+++ b/src/Playroom/CodeEditor/CodeEditor.tsx
@@ -298,15 +298,6 @@ export const CodeEditor = ({
           ['Shift-Ctrl-R']: false, // override default keybinding
           ['Cmd-Option-F']: false, // override default keybinding
           ['Shift-Cmd-Option-F']: false, // override default keybinding
-          [`Shift-${keymapModifierKey}-C`]: () => {
-            dispatch({
-              type: 'copyToClipboard',
-              payload: {
-                url: window.location.href,
-                trigger: 'toolbarItem',
-              },
-            });
-          },
         },
       }}
     />

--- a/src/Playroom/SettingsPanel/SettingsPanel.tsx
+++ b/src/Playroom/SettingsPanel/SettingsPanel.tsx
@@ -32,7 +32,6 @@ const getKeyBindings = () => {
     'Wrap selection in tag': [metaKeySymbol, shiftKeySymbol, ','],
     'Format code': [metaKeySymbol, 'S'],
     'Insert snippet': [metaKeySymbol, 'K'],
-    'Copy Playroom link': [metaKeySymbol, shiftKeySymbol, 'C'],
     'Select next occurrence': [metaKeySymbol, 'D'],
     'Jump to line number': [metaKeySymbol, 'G'],
     'Swap line up': [altKeySymbol, '↑'],

--- a/src/Playroom/Toolbar/Toolbar.tsx
+++ b/src/Playroom/Toolbar/Toolbar.tsx
@@ -135,7 +135,7 @@ export default ({ themes: allThemes, widths: allWidths, snippets }: Props) => {
 
           <div>
             <ToolbarItem
-              title={`Copy Playroom link (${isMac() ? '⌘⇧C' : 'Ctrl+Shift+C'})`}
+              title="Copy Playroom link"
               success={copying}
               onClick={copyHandler}
             >


### PR DESCRIPTION
The current shortcut (⌘⇧C on Mac) conflicts with the dev tools inspector mode shortcut in Chrome (and other browsers) which is very useful in Playroom.

Removing this shortcut to prevent the conflict, as I suspect it does not have much use.