### PR TITLE
Use URL hash for iframe params regardless of configured `paramType`

### DIFF
--- a/.changeset/moody-poets-cross.md
+++ b/.changeset/moody-poets-cross.md
@@ -1,0 +1,7 @@
+---
+'playroom': patch
+---
+
+Use the URL hash for passing params to each playroom iframe even when `paramType: 'search'` is configured
+
+This change prevents a full React re-render from occurring whenever code is changed in a playroom in projects that configure `paramType: 'search'`, resulting in a much smoother prototyping experience.

--- a/src/Playroom/Frames/frameSrc.js
+++ b/src/Playroom/Frames/frameSrc.js
@@ -1,11 +1,9 @@
 // eslint-disable-next-line import/no-unresolved
 const frameConfig = require('__PLAYROOM_ALIAS__FRAME_COMPONENT__');
 
-const defaultFrameSrc = ({ code, themeName }, { baseUrl, paramType }) =>
-  `${baseUrl}frame.html${
-    paramType === 'hash' ? '#' : ''
-  }?themeName=${encodeURIComponent(themeName)}&code=${encodeURIComponent(
-    code
-  )}`;
+const defaultFrameSrc = ({ code, themeName }, { baseUrl }) =>
+  `${baseUrl}frame.html#?themeName=${encodeURIComponent(
+    themeName
+  )}&code=${encodeURIComponent(code)}`;
 
 module.exports = frameConfig.frameSrc ? frameConfig.frameSrc : defaultFrameSrc;

--- a/src/utils/params.ts
+++ b/src/utils/params.ts
@@ -22,14 +22,10 @@ export function updateUrlCode(code: string) {
 export function getParamsFromQuery(location = history.location) {
   try {
     // Prefer checking `hash`, fall back to `search` in case the user has configured a custom
-    // `frameSrc` function that sets search params instead of the hash
-    const isParamsInHash = location.hash.startsWith('#?');
-
-    if (isParamsInHash) {
-      return new URLSearchParams(location.hash.slice(1));
-    }
-
-    return new URLSearchParams(location.search);
+    // `frameSrc` function that uses search params instead of the hash
+    return new URLSearchParams(
+      location.hash.startsWith('#?') ? location.hash.slice(1) : location.search
+    );
   } catch {
     return new URLSearchParams();
   }

--- a/src/utils/params.ts
+++ b/src/utils/params.ts
@@ -21,12 +21,16 @@ export function updateUrlCode(code: string) {
 
 export function getParamsFromQuery(location = history.location) {
   try {
-    return new URLSearchParams(
-      playroomConfig.paramType === 'hash'
-        ? location.hash.replace(/^#/, '')
-        : location.search
-    );
-  } catch (err) {
+    // Prefer checking `hash`, fall back to `search` in case the user has configured a custom
+    // `frameSrc` function that sets search params instead of the hash
+    const isParamsInHash = location.hash.startsWith('#?');
+
+    if (isParamsInHash) {
+      return new URLSearchParams(location.hash.slice(1));
+    }
+
+    return new URLSearchParams(location.search);
+  } catch {
     return new URLSearchParams();
   }
 }


### PR DESCRIPTION
## Hash vs Search

Changes to search params trigger browser navigation. Practically this means that every time your playroom code changes, every iframe's query params are updated, which results in the browser reloading the iframe document (multiplied by the number of frames being shown), and doing a full React render, which is quite slow.

On the other hand, URL hash updates do not cause navigations, which is why `paramType` defaults to `hash`, as it is simply the better option. When the hash updates, the entire iframe doesn't reload. Instead, the new JSX is rendered by the existing React root, but obviously only a tiny part of the DOM has changed, so React update's the fraction of the DOM that has changed nearly instantly.

However, some users host their playroom behind some kind of internal auth. Redirects that occur during authentication often strip URL hashes, which is why `paramType: 'search'` exists, with the tradeoff being a slower prototyping experience.

## Solution

By using the URL hash for passing playroom params to the iframe, regardless of `paramType`, users that set `paramType: 'search'` can have their cake and eat it too. That is, they can use query params for sharing playrooms, while still benefiting from the rendering speed offered by URL hash updates.

Before:

[Before.webm](https://github.com/user-attachments/assets/83ee0838-b7a6-47ff-b913-f95a1a1aa314)

After:

[After.webm](https://github.com/user-attachments/assets/16903daf-7daf-4b8c-aed6-8e9c13600aa9)

## Caveats

There are potentially some consumers that won't benefit from this because they configure a custom `frameSrc` function that doesn't use the URL hash. This feature isn't documented and is considered experimental, so supporting them is outside the scope of this PR.