### PR TITLE
CLI: Only require modules that are relevant to the CLI command being executed

### DIFF
--- a/.changeset/fluffy-shrimps-switch.md
+++ b/.changeset/fluffy-shrimps-switch.md
@@ -1,0 +1,5 @@
+---
+'playroom': patch
+---
+
+CLI: Only require modules that are relevant to the CLI command being executed

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,16 @@
-const start = require('./start');
-const build = require('./build');
 const provideDefaultConfig = require('./provideDefaultConfig');
 
 module.exports = (userConfig) => {
   const config = provideDefaultConfig(userConfig);
 
   return {
-    start: (callback) => start(config, callback),
-    build: (callback) => build(config, callback),
+    start: (callback) => {
+      const start = require('./start');
+      start(config, callback);
+    },
+    build: (callback) => {
+      const build = require('./build');
+      build(config, callback);
+    },
   };
 };


### PR DESCRIPTION
Fixes #407.

Currently, all modules that handle CLI commands (`start` and `build`) are required during CLI execution, regardless of which command is being executed. This causes pollution of the `build` environment, as described in #407.

This PR fixes the issue by `require`ing the relevant command's module within that command's function.