### PR TITLE
Improve snippet search result sorting

### DIFF
--- a/.changeset/loose-states-rescue.md
+++ b/.changeset/loose-states-rescue.md
@@ -1,0 +1,11 @@
+---
+'playroom': minor
+---
+
+Improve snippets search ranking algorithm.
+Results are now sorted primarily by the `group` property over the `name` property, making it easier to see related snippets together.
+
+Replace [`fuzzy`] dependency with [`fuse.js`] to enable result sorting.
+
+[`fuzzy`]: https://github.com/mattyork/fuzzy?tab=readme-ov-file
+[`fuse.js`]: https://github.com/krisk/fuse

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "css-loader": "^6.7.2",
     "dedent": "^1.5.1",
     "find-up": "^5.0.0",
-    "fuzzy": "^0.1.3",
+    "fuse.js": "^7.1.0",
     "history": "^5.3.0",
     "html-webpack-plugin": "^5.5.0",
     "localforage": "^1.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,9 +86,9 @@ importers:
       find-up:
         specifier: ^5.0.0
         version: 5.0.0
-      fuzzy:
-        specifier: ^0.1.3
-        version: 0.1.3
+      fuse.js:
+        specifier: ^7.1.0
+        version: 7.1.0
       history:
         specifier: ^5.3.0
         version: 5.3.0
@@ -3042,9 +3042,9 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  fuzzy@0.1.3:
-    resolution: {integrity: sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==}
-    engines: {node: '>= 0.6.0'}
+  fuse.js@7.1.0:
+    resolution: {integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==}
+    engines: {node: '>=10'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -9167,7 +9167,7 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  fuzzy@0.1.3: {}
+  fuse.js@7.1.0: {}
 
   gensync@1.0.0-beta.2: {}
 

--- a/src/Playroom/Snippets/Snippets.tsx
+++ b/src/Playroom/Snippets/Snippets.tsx
@@ -50,17 +50,13 @@ export default ({ isOpen, snippets, onHighlight, onClose }: Props) => {
   const highlightedEl = useRef<HTMLLIElement | null>(null);
 
   const fuse = useMemo(() => new Fuse(snippets, options), [snippets]);
-  const fuseResults = useMemo(
-    () => (searchTerm ? fuse.search(searchTerm) : []),
-    [fuse, searchTerm]
-  );
 
   const filteredSnippets = useMemo(
     () =>
-      fuseResults.length > 0
-        ? fuseResults.map((result) => result.item)
+      searchTerm
+        ? fuse.search(searchTerm).map((result) => result.item)
         : snippets,
-    [fuseResults, snippets]
+    [fuse, searchTerm, snippets]
   );
 
   const closeHandler = (returnValue: ReturnedSnippet) => {

--- a/src/Playroom/Snippets/Snippets.tsx
+++ b/src/Playroom/Snippets/Snippets.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
-import fuzzy from 'fuzzy';
-import { useState, useEffect, useMemo, useRef } from 'react';
+import Fuse from 'fuse.js';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 
 import type { Snippet } from '../../../utils';
@@ -27,26 +27,48 @@ function getSnippetId(snippet: Snippet, index: number) {
   return `${snippet.group}_${snippet.name}_${index}`;
 }
 
-const filterSnippetsForTerm = (snippets: Props['snippets'], term: string) =>
-  term
-    ? fuzzy
-        .filter(term, snippets, {
-          extract: (snippet) => `${snippet.group} ${snippet.name}`,
-        })
-        .map(({ original, score }) => ({ ...original, score }))
-    : snippets;
+const options = {
+  threshold: 0.3,
+  keys: [
+    {
+      name: 'group',
+      weight: 2,
+    },
+    {
+      name: 'name',
+      weight: 1,
+    },
+  ],
+};
 
 export default ({ isOpen, snippets, onHighlight, onClose }: Props) => {
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [highlightedIndex, setHighlightedIndex] =
     useState<HighlightIndex>(null);
+
   const listEl = useRef<HTMLUListElement | null>(null);
   const highlightedEl = useRef<HTMLLIElement | null>(null);
+
+  const fuse = useMemo(() => new Fuse(snippets, options), [snippets]);
+  const fuseResults = useMemo(
+    () => (searchTerm ? fuse.search(searchTerm) : []),
+    [fuse, searchTerm]
+  );
+
+  const filteredSnippets = useMemo(
+    () =>
+      fuseResults.length > 0
+        ? fuseResults.map((result) => result.item)
+        : snippets,
+    [fuseResults, snippets]
+  );
+
   const closeHandler = (returnValue: ReturnedSnippet) => {
     if (typeof onClose === 'function') {
       onClose(returnValue);
     }
   };
+
   const debouncedPreview = useDebouncedCallback(
     (previewSnippet: ReturnedSnippet) => {
       if (typeof onHighlight === 'function') {
@@ -54,11 +76,6 @@ export default ({ isOpen, snippets, onHighlight, onClose }: Props) => {
       }
     },
     50
-  );
-
-  const filteredSnippets = useMemo(
-    () => filterSnippetsForTerm(snippets, searchTerm),
-    [searchTerm, snippets]
   );
 
   if (


### PR DESCRIPTION
This change makes it easy to add more snippets without making it harder to search through them to find the correct result

I have put a snapshot release to test in the Braid Design System Playroom.

> Try searching 'badge' in each of the following to compare

- [Current search](https://seek-oss.github.io/braid-design-system/playroom/#?code=N4IgLgFgpgtlDOIBcBtE8pQNYCkD2ARogLoA0IA7gJYAmkiqIAYlWAARh5vUB2NeFEMQC%2BQA)
- [Improved search](https://seek-oss.github.io/braid-design-system/preview/fc5c12b473dd7e523a4a3b2f3703cbf9a7cf4aff/playroom/#?code=N4IgLgFgpgtlDOIBcBtE8pQNYCkD2ARogLoA0IA7gJYAmkiqIAYlWAARh5vUB2NeFEMQC%2BQA)