### PR TITLE
refactor: Move `Playroom` to sub-component folder

### DIFF
--- a/cypress/e2e/toolbar.cy.ts
+++ b/cypress/e2e/toolbar.cy.ts
@@ -1,4 +1,4 @@
-import type { PlayroomProps } from '../../src/Playroom/Playroom';
+import type { PlayroomProps } from '../../src/Playroom/Playroom/Playroom';
 import {
   assertFramesMatch,
   assertPreviewContains,

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -3,7 +3,7 @@
 import dedent from 'dedent';
 
 import type { Direction } from '../../src/Playroom/CodeEditor/keymaps/types';
-import type { PlayroomProps } from '../../src/Playroom/Playroom';
+import type { PlayroomProps } from '../../src/Playroom/Playroom/Playroom';
 import { isMac } from '../../src/utils/formatting';
 import { createUrl } from '../../utils';
 

--- a/src/Playroom/Frames/Frames.tsx
+++ b/src/Playroom/Frames/Frames.tsx
@@ -5,7 +5,7 @@ import playroomConfig from '../../config';
 import { compileJsx } from '../../utils/compileJsx';
 import { Box } from '../Box/Box';
 import { ReceiveErrorMessage } from '../Frame/frameMessaging';
-import type { PlayroomProps } from '../Playroom';
+import type { PlayroomProps } from '../Playroom/Playroom';
 import { Strong } from '../Strong/Strong';
 import { Text } from '../Text/Text';
 

--- a/src/Playroom/FramesPanel/FramesPanel.tsx
+++ b/src/Playroom/FramesPanel/FramesPanel.tsx
@@ -4,7 +4,7 @@ import { StoreContext } from '../../contexts/StoreContext';
 import { Box } from '../Box/Box';
 import { Heading } from '../Heading/Heading';
 import { Inline } from '../Inline/Inline';
-import type { PlayroomProps } from '../Playroom';
+import type { PlayroomProps } from '../Playroom/Playroom';
 import { Stack } from '../Stack/Stack';
 import { Text } from '../Text/Text';
 import { ToolbarPanel } from '../ToolbarPanel/ToolbarPanel';

--- a/src/Playroom/Playroom/Playroom.css.ts
+++ b/src/Playroom/Playroom/Playroom.css.ts
@@ -9,11 +9,11 @@ import {
   ANIMATION_TIMEOUT,
   toolbarItemCount,
   toolbarOpenSize,
-} from './constants';
+} from '../constants';
 
-import { toolbarItemSize } from './ToolbarItem/ToolbarItem.css';
-import { sprinkles, colorPaletteVars } from '../css/sprinkles.css';
-import { vars } from '../css/vars.css';
+import { sprinkles, colorPaletteVars } from '../../css/sprinkles.css';
+import { vars } from '../../css/vars.css';
+import { toolbarItemSize } from '../ToolbarItem/ToolbarItem.css';
 
 const MIN_HEIGHT = `${toolbarItemSize * toolbarItemCount}px`;
 const MIN_WIDTH = `${toolbarOpenSize + toolbarItemSize + 80}px`;

--- a/src/Playroom/Playroom/Playroom.tsx
+++ b/src/Playroom/Playroom/Playroom.tsx
@@ -11,18 +11,17 @@ import {
 import { Helmet } from 'react-helmet';
 import { useDebouncedCallback } from 'use-debounce';
 
-import type { Snippets } from '../../utils';
-import { StoreContext, type EditorPosition } from '../contexts/StoreContext';
-import componentsToHints from '../utils/componentsToHints';
-
-import { Box } from './Box/Box';
-import { CodeEditor } from './CodeEditor/CodeEditor';
-import Frames from './Frames/Frames';
-import { StatusMessage } from './StatusMessage/StatusMessage';
-import Toolbar from './Toolbar/Toolbar';
-import { WindowPortal } from './WindowPortal';
-import { ANIMATION_TIMEOUT } from './constants';
-import ChevronIcon from './icons/ChevronIcon';
+import type { Snippets } from '../../../utils';
+import { StoreContext, type EditorPosition } from '../../contexts/StoreContext';
+import componentsToHints from '../../utils/componentsToHints';
+import { Box } from '../Box/Box';
+import { CodeEditor } from '../CodeEditor/CodeEditor';
+import Frames from '../Frames/Frames';
+import { StatusMessage } from '../StatusMessage/StatusMessage';
+import Toolbar from '../Toolbar/Toolbar';
+import { WindowPortal } from '../WindowPortal';
+import { ANIMATION_TIMEOUT } from '../constants';
+import ChevronIcon from '../icons/ChevronIcon';
 
 import * as styles from './Playroom.css';
 

--- a/src/Playroom/Snippets/Snippets.tsx
+++ b/src/Playroom/Snippets/Snippets.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, useMemo } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 
 import type { Snippet } from '../../../utils';
-import type { PlayroomProps } from '../Playroom';
+import type { PlayroomProps } from '../Playroom/Playroom';
 import { Stack } from '../Stack/Stack';
 import { Text } from '../Text/Text';
 

--- a/src/Playroom/Toolbar/Toolbar.tsx
+++ b/src/Playroom/Toolbar/Toolbar.tsx
@@ -5,7 +5,7 @@ import { CSSTransition } from 'react-transition-group';
 import { StoreContext } from '../../contexts/StoreContext';
 import { isMac } from '../../utils/formatting';
 import FramesPanel from '../FramesPanel/FramesPanel';
-import type { PlayroomProps } from '../Playroom';
+import type { PlayroomProps } from '../Playroom/Playroom';
 import PreviewPanel from '../PreviewPanel/PreviewPanel';
 import SettingsPanel from '../SettingsPanel/SettingsPanel';
 import Snippets from '../Snippets/Snippets';

--- a/src/contexts/StoreContext.tsx
+++ b/src/contexts/StoreContext.tsx
@@ -12,7 +12,7 @@ import {
 import { useDebouncedCallback } from 'use-debounce';
 
 import { type Snippet, compressParams } from '../../utils';
-import type { PlayroomProps } from '../Playroom/Playroom';
+import type { PlayroomProps } from '../Playroom/Playroom/Playroom';
 import playroomConfig from '../config';
 import { isValidLocation } from '../utils/cursor';
 import { formatForInsertion, formatAndInsert } from '../utils/formatting';

--- a/src/entries/index.tsx
+++ b/src/entries/index.tsx
@@ -1,6 +1,6 @@
 import faviconInvertedPath from '../../images/favicon-inverted.png';
 import faviconPath from '../../images/favicon.png';
-import Playroom, { type PlayroomProps } from '../Playroom/Playroom';
+import Playroom, { type PlayroomProps } from '../Playroom/Playroom/Playroom';
 import playroomComponents from '../components';
 import playroomConfig from '../config';
 import { StoreProvider } from '../contexts/StoreContext';

--- a/src/utils/componentsToHints.ts
+++ b/src/utils/componentsToHints.ts
@@ -1,7 +1,7 @@
 // @ts-expect-error
 import parsePropTypes from 'parse-prop-types';
 
-import type { PlayroomProps } from '../Playroom/Playroom';
+import type { PlayroomProps } from '../Playroom/Playroom/Playroom';
 
 export default (
   components: PlayroomProps['components'],

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,6 +1,6 @@
 import { compressToEncodedURIComponent } from 'lz-string';
 
-import type { Widths } from '../src/Playroom/Playroom';
+import type { Widths } from '../src/Playroom/Playroom/Playroom';
 
 export interface Snippet {
   group: string;


### PR DESCRIPTION
Part four, move `Playroom` component into `Playroom` (soon to be `components`) folder.

Temporarily results in some `Playroom/Playroom/Playroom' paths, that will update shortly.