### PR TITLE
refactor: Create and adopt `widths` config module

### DIFF
--- a/cypress/e2e/toolbar.cy.ts
+++ b/cypress/e2e/toolbar.cy.ts
@@ -1,4 +1,4 @@
-import type { PlayroomProps } from '../../src/components/Playroom/Playroom';
+import type { Widths } from '../../src/configModules/widths';
 import {
   assertFramesMatch,
   assertPreviewContains,
@@ -15,13 +15,7 @@ describe('Toolbar', () => {
   });
 
   it('filter widths', () => {
-    const frames: PlayroomProps['widths'] = [
-      320,
-      375,
-      768,
-      1024,
-      'Fit to window',
-    ];
+    const frames: Widths = [320, 375, 768, 1024, 'Fit to window'];
     const widthIndexToSelect = 1;
 
     assertFramesMatch(frames);

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -3,7 +3,7 @@
 import dedent from 'dedent';
 
 import type { Direction } from '../../src/components/CodeEditor/keymaps/types';
-import type { PlayroomProps } from '../../src/components/Playroom/Playroom';
+import type { Widths } from '../../src/configModules/widths';
 import { isMac } from '../../src/utils/formatting';
 import { createUrl } from '../../utils';
 
@@ -39,9 +39,7 @@ export const formatCode = () =>
     .focused()
     .type(`${isMac() ? '{cmd}' : '{ctrl}'}s`);
 
-export const selectWidthPreference = (
-  width: PlayroomProps['widths'][number]
-) => {
+export const selectWidthPreference = (width: Widths[number]) => {
   cy.findByRole('button', { name: 'Configure visible frames' }).click();
   cy.findByRole('checkbox', { name: `${width}` }).click();
 };
@@ -181,9 +179,7 @@ export const assertCodePaneLineCount = (
 };
 
 export const assertFramesMatch = (
-  frames:
-    | PlayroomProps['widths']
-    | Array<[frameTheme: string, frameWidth: PlayroomProps['widths'][number]]>
+  frames: Widths | Array<[frameTheme: string, frameWidth: Widths[number]]>
 ) => {
   const formattedFrames = frames.map((frame) => {
     if (frame === 'Fit to window') {

--- a/src/components/Frames/Frames.tsx
+++ b/src/components/Frames/Frames.tsx
@@ -1,7 +1,9 @@
 import { assignInlineVars } from '@vanilla-extract/dynamic';
-import { useRef } from 'react';
+import { useContext, useRef } from 'react';
 
 import playroomConfig from '../../config';
+import availableWidths from '../../configModules/widths';
+import { StoreContext } from '../../contexts/StoreContext';
 import { compileJsx } from '../../utils/compileJsx';
 import { Box } from '../Box/Box';
 import { ReceiveErrorMessage } from '../Frame/frameMessaging';
@@ -17,10 +19,12 @@ import * as styles from './Frames.css';
 interface FramesProps {
   code: string;
   themes: PlayroomProps['themes'];
-  widths: PlayroomProps['widths'];
 }
 
-export default function Frames({ code, themes, widths }: FramesProps) {
+export default function Frames({ code, themes }: FramesProps) {
+  const [{ visibleWidths }] = useContext(StoreContext);
+  const widths =
+    visibleWidths && visibleWidths.length > 0 ? visibleWidths : availableWidths;
   const scrollingPanelRef = useRef<HTMLDivElement | null>(null);
   const renderCode = useRef<string>('');
 

--- a/src/components/FramesPanel/FramesPanel.tsx
+++ b/src/components/FramesPanel/FramesPanel.tsx
@@ -1,10 +1,10 @@
 import { useContext, type ReactNode } from 'react';
 
+import availableWidths from '../../configModules/widths';
 import { StoreContext } from '../../contexts/StoreContext';
 import { Box } from '../Box/Box';
 import { Heading } from '../Heading/Heading';
 import { Inline } from '../Inline/Inline';
-import type { PlayroomProps } from '../Playroom/Playroom';
 import { Stack } from '../Stack/Stack';
 import { Text } from '../Text/Text';
 import { ToolbarPanel } from '../ToolbarPanel/ToolbarPanel';
@@ -14,7 +14,6 @@ import Checkmark from './CheckmarkSvg';
 import * as styles from './FramesPanel.css';
 
 interface FramesPanelProps {
-  availableWidths: PlayroomProps['widths'];
   availableThemes: string[];
 }
 
@@ -80,7 +79,7 @@ function FrameOption<Option>({
   );
 }
 
-export default ({ availableWidths, availableThemes }: FramesPanelProps) => {
+export default ({ availableThemes }: FramesPanelProps) => {
   const [{ visibleWidths = [], visibleThemes = [], title }, dispatch] =
     useContext(StoreContext);
   const hasThemes =

--- a/src/components/Playroom/Playroom.tsx
+++ b/src/components/Playroom/Playroom.tsx
@@ -63,18 +63,13 @@ const getTitle = (title: string | undefined) => {
   return 'Playroom';
 };
 
-// Separating out `Widths` to prevent `PlayroomProps` from being bundled in the `utils` type
-// definitions
-export type Widths = Array<number | 'Fit to window'>;
-
 export interface PlayroomProps {
   components: Record<string, ComponentType<any>>;
   themes: string[];
-  widths: Widths;
   snippets: Snippets;
 }
 
-export default ({ components, themes, widths, snippets }: PlayroomProps) => {
+export default ({ components, themes, snippets }: PlayroomProps) => {
   const [
     {
       editorPosition,
@@ -82,7 +77,6 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
       editorWidth,
       editorHidden,
       visibleThemes,
-      visibleWidths,
       code,
       previewRenderCode,
       previewEditorCode,
@@ -152,7 +146,7 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
         <StatusMessage />
       </div>
       <div className={styles.toolbarContainer}>
-        <Toolbar widths={widths} themes={themes} snippets={snippets} />
+        <Toolbar themes={themes} snippets={snippets} />
       </div>
     </Fragment>
   );
@@ -236,9 +230,6 @@ export default ({ components, themes, widths, snippets }: PlayroomProps) => {
           code={previewRenderCode || code}
           themes={
             visibleThemes && visibleThemes.length > 0 ? visibleThemes : themes
-          }
-          widths={
-            visibleWidths && visibleWidths.length > 0 ? visibleWidths : widths
           }
         />
         <div

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -21,11 +21,10 @@ import * as styles from './Toolbar.css';
 
 interface Props {
   themes: PlayroomProps['themes'];
-  widths: PlayroomProps['widths'];
   snippets: PlayroomProps['snippets'];
 }
 
-export default ({ themes: allThemes, widths: allWidths, snippets }: Props) => {
+export default ({ themes: allThemes, snippets }: Props) => {
   const [
     {
       visibleThemes = [],
@@ -189,10 +188,7 @@ export default ({ themes: allThemes, widths: allWidths, snippets }: Props) => {
             )}
 
             {lastActivePanel === 'frames' && (
-              <FramesPanel
-                availableWidths={allWidths}
-                availableThemes={allThemes}
-              />
+              <FramesPanel availableThemes={allThemes} />
             )}
 
             {lastActivePanel === 'preview' && (

--- a/src/configModules/widths.ts
+++ b/src/configModules/widths.ts
@@ -1,0 +1,8 @@
+import playroomConfig from '../config';
+
+export type Widths = Array<number | 'Fit to window'>;
+
+const suppliedWidths = playroomConfig.widths || [320, 375, 768, 1024];
+const widths: Widths = [...suppliedWidths, 'Fit to window'];
+
+export default widths;

--- a/src/contexts/StoreContext.tsx
+++ b/src/contexts/StoreContext.tsx
@@ -14,6 +14,7 @@ import { useDebouncedCallback } from 'use-debounce';
 import { type Snippet, compressParams } from '../../utils';
 import type { PlayroomProps } from '../components/Playroom/Playroom';
 import playroomConfig from '../config';
+import availableWidths, { type Widths } from '../configModules/widths';
 import { isValidLocation } from '../utils/cursor';
 import { formatForInsertion, formatAndInsert } from '../utils/formatting';
 import { getParamsFromQuery, updateUrlCode } from '../utils/params';
@@ -58,7 +59,7 @@ function convertAndStoreSizeAsPercentage(
 interface DebounceUpdateUrl {
   code?: string;
   themes?: string[];
-  widths?: PlayroomProps['widths'];
+  widths?: Widths;
   title?: string;
   editorHidden?: boolean;
 }
@@ -89,7 +90,7 @@ interface State {
   editorWidth: string;
   statusMessage?: StatusMessage;
   visibleThemes?: string[];
-  visibleWidths?: PlayroomProps['widths'];
+  visibleWidths?: Widths;
   ready: boolean;
   colorScheme: ColorScheme;
 }
@@ -127,7 +128,7 @@ type Action =
   | { type: 'resetVisibleThemes' }
   | {
       type: 'updateVisibleWidths';
-      payload: { widths: PlayroomProps['widths'] };
+      payload: { widths: Widths };
     }
   | { type: 'resetVisibleWidths' }
   | { type: 'updateTitle'; payload: { title: string } };
@@ -141,13 +142,9 @@ const resetPreview = ({
 
 interface CreateReducerParams {
   themes: PlayroomProps['themes'];
-  widths: PlayroomProps['widths'];
 }
 const createReducer =
-  ({
-    themes: configuredThemes,
-    widths: configuredWidths,
-  }: CreateReducerParams) =>
+  ({ themes: configuredThemes }: CreateReducerParams) =>
   (state: State, action: Action): State => {
     switch (action.type) {
       case 'initialLoad': {
@@ -398,9 +395,7 @@ const createReducer =
 
       case 'updateVisibleWidths': {
         const { widths } = action.payload;
-        const visibleWidths = configuredWidths.filter((w) =>
-          widths.includes(w)
-        );
+        const visibleWidths = availableWidths.filter((w) => widths.includes(w));
         store.setItem('visibleWidths', visibleWidths);
 
         return {
@@ -452,16 +447,11 @@ export const StoreContext = createContext<StoreContextValues>([
 export const StoreProvider = ({
   children,
   themes,
-  widths,
 }: {
   children: ReactNode;
   themes: PlayroomProps['themes'];
-  widths: PlayroomProps['widths'];
 }) => {
-  const [state, dispatch] = useReducer(
-    createReducer({ themes, widths }),
-    initialState
-  );
+  const [state, dispatch] = useReducer(createReducer({ themes }), initialState);
   const debouncedCodeUpdate = useDebouncedCallback(
     (params: DebounceUpdateUrl) => {
       // Ensure that when removing theme/width preferences

--- a/src/entries/index.tsx
+++ b/src/entries/index.tsx
@@ -1,15 +1,11 @@
 import faviconInvertedPath from '../../images/favicon-inverted.png';
 import faviconPath from '../../images/favicon.png';
-import Playroom, { type PlayroomProps } from '../components/Playroom/Playroom';
-import playroomConfig from '../config';
+import Playroom from '../components/Playroom/Playroom';
 import components from '../configModules/components';
 import snippets from '../configModules/snippets';
 import themes from '../configModules/themes';
 import { StoreProvider } from '../contexts/StoreContext';
 import { renderElement } from '../render';
-
-const suppliedWidths = playroomConfig.widths || [320, 375, 768, 1024];
-const widths: PlayroomProps['widths'] = [...suppliedWidths, 'Fit to window'];
 
 const outlet = document.createElement('div');
 document.body.appendChild(outlet);
@@ -26,13 +22,8 @@ if (selectedElement) {
 const themeNames = Object.keys(themes);
 
 renderElement(
-  <StoreProvider themes={themeNames} widths={widths}>
-    <Playroom
-      components={components}
-      widths={widths}
-      themes={themeNames}
-      snippets={snippets}
-    />
+  <StoreProvider themes={themeNames}>
+    <Playroom components={components} themes={themeNames} snippets={snippets} />
   </StoreProvider>,
   outlet
 );

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,6 +1,6 @@
 import { compressToEncodedURIComponent } from 'lz-string';
 
-import type { Widths } from '../src/components/Playroom/Playroom';
+import type { Widths } from '../src/configModules/widths';
 
 export interface Snippet {
   group: string;


### PR DESCRIPTION
Refactor `widths` to be accessible via config module pattern rather than prop-drilling.