### PR TITLE
refactor: Expose `themeNames` via `themes` config module

### DIFF
--- a/src/components/Frames/Frames.tsx
+++ b/src/components/Frames/Frames.tsx
@@ -2,12 +2,12 @@ import { assignInlineVars } from '@vanilla-extract/dynamic';
 import { useContext, useRef } from 'react';
 
 import playroomConfig from '../../config';
+import { themeNames as availableThemes } from '../../configModules/themes';
 import availableWidths from '../../configModules/widths';
 import { StoreContext } from '../../contexts/StoreContext';
 import { compileJsx } from '../../utils/compileJsx';
 import { Box } from '../Box/Box';
 import { ReceiveErrorMessage } from '../Frame/frameMessaging';
-import type { PlayroomProps } from '../Playroom/Playroom';
 import { Strong } from '../Strong/Strong';
 import { Text } from '../Text/Text';
 
@@ -18,11 +18,12 @@ import * as styles from './Frames.css';
 
 interface FramesProps {
   code: string;
-  themes: PlayroomProps['themes'];
 }
 
-export default function Frames({ code, themes }: FramesProps) {
-  const [{ visibleWidths }] = useContext(StoreContext);
+export default function Frames({ code }: FramesProps) {
+  const [{ visibleWidths, visibleThemes }] = useContext(StoreContext);
+  const themes =
+    visibleThemes && visibleThemes.length > 0 ? visibleThemes : availableThemes;
   const widths =
     visibleWidths && visibleWidths.length > 0 ? visibleWidths : availableWidths;
   const scrollingPanelRef = useRef<HTMLDivElement | null>(null);

--- a/src/components/FramesPanel/FramesPanel.tsx
+++ b/src/components/FramesPanel/FramesPanel.tsx
@@ -1,5 +1,6 @@
 import { useContext, type ReactNode } from 'react';
 
+import { themeNames as availableThemes } from '../../configModules/themes';
 import availableWidths from '../../configModules/widths';
 import { StoreContext } from '../../contexts/StoreContext';
 import { Box } from '../Box/Box';
@@ -12,10 +13,6 @@ import { ToolbarPanel } from '../ToolbarPanel/ToolbarPanel';
 import Checkmark from './CheckmarkSvg';
 
 import * as styles from './FramesPanel.css';
-
-interface FramesPanelProps {
-  availableThemes: string[];
-}
 
 interface ResetButtonProps {
   onClick: () => void;
@@ -79,7 +76,7 @@ function FrameOption<Option>({
   );
 }
 
-export default ({ availableThemes }: FramesPanelProps) => {
+export default () => {
   const [{ visibleWidths = [], visibleThemes = [], title }, dispatch] =
     useContext(StoreContext);
   const hasThemes =

--- a/src/components/Playroom/Playroom.tsx
+++ b/src/components/Playroom/Playroom.tsx
@@ -65,18 +65,16 @@ const getTitle = (title: string | undefined) => {
 
 export interface PlayroomProps {
   components: Record<string, ComponentType<any>>;
-  themes: string[];
   snippets: Snippets;
 }
 
-export default ({ components, themes, snippets }: PlayroomProps) => {
+export default ({ components, snippets }: PlayroomProps) => {
   const [
     {
       editorPosition,
       editorHeight,
       editorWidth,
       editorHidden,
-      visibleThemes,
       code,
       previewRenderCode,
       previewEditorCode,
@@ -146,7 +144,7 @@ export default ({ components, themes, snippets }: PlayroomProps) => {
         <StatusMessage />
       </div>
       <div className={styles.toolbarContainer}>
-        <Toolbar themes={themes} snippets={snippets} />
+        <Toolbar snippets={snippets} />
       </div>
     </Fragment>
   );
@@ -226,12 +224,7 @@ export default ({ components, themes, snippets }: PlayroomProps) => {
       )}
 
       <Box position="relative" flexGrow={1} className={styles.previewContainer}>
-        <Frames
-          code={previewRenderCode || code}
-          themes={
-            visibleThemes && visibleThemes.length > 0 ? visibleThemes : themes
-          }
-        />
+        <Frames code={previewRenderCode || code} />
         <div
           className={clsx(styles.toggleEditorContainer, {
             [styles.isBottom]: isHorizontalEditor,

--- a/src/components/PreviewPanel/PreviewPanel.tsx
+++ b/src/components/PreviewPanel/PreviewPanel.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 
+import { themeNames } from '../../configModules/themes';
+import { StoreContext } from '../../contexts/StoreContext';
 import usePreviewUrl from '../../utils/usePreviewUrl';
 import { Button } from '../Button/Button';
 import { Heading } from '../Heading/Heading';
@@ -11,20 +13,19 @@ import PlayIcon from '../icons/PlayIcon';
 import { CopyButton } from './CopyButton';
 import { ThemeSelector } from './ThemeSelector';
 
-interface PreviewPanelProps {
-  themes: string[];
-  visibleThemes: string[] | undefined;
-}
-export default ({ themes, visibleThemes }: PreviewPanelProps) => {
+export default () => {
+  const [{ visibleThemes = [] }] = useContext(StoreContext);
   const defaultTheme =
-    visibleThemes && visibleThemes.length > 0 ? visibleThemes[0] : themes[0];
+    visibleThemes && visibleThemes.length > 0
+      ? visibleThemes[0]
+      : themeNames[0];
   const [userSelectedTheme, setUserSelectedTheme] = useState<
     string | undefined
   >();
 
   const activeTheme = userSelectedTheme || defaultTheme;
 
-  const isThemed = themes.length > 1;
+  const isThemed = themeNames.length > 1;
 
   const prototypeUrl = usePreviewUrl(activeTheme);
 
@@ -37,7 +38,6 @@ export default ({ themes, visibleThemes }: PreviewPanelProps) => {
 
         {isThemed ? (
           <ThemeSelector
-            themes={themes}
             visibleThemes={visibleThemes}
             activeTheme={activeTheme}
             onChange={setUserSelectedTheme}

--- a/src/components/PreviewPanel/ThemeSelector.tsx
+++ b/src/components/PreviewPanel/ThemeSelector.tsx
@@ -1,13 +1,13 @@
 import clsx from 'clsx';
 import { Fragment } from 'react';
 
+import { themeNames } from '../../configModules/themes';
 import { Text } from '../Text/Text';
 import ChevronIcon from '../icons/ChevronIcon';
 
 import * as styles from './ThemeSelector.css';
 
 interface ThemeSelectorProps {
-  themes: string[];
   visibleThemes: string[] | undefined;
   activeTheme: string;
   onChange: (theme: string) => void;
@@ -20,7 +20,6 @@ const themeOption = (theme: string) => (
 );
 
 export const ThemeSelector = ({
-  themes,
   activeTheme,
   onChange,
   visibleThemes,
@@ -32,13 +31,13 @@ export const ThemeSelector = ({
           {visibleThemes.map(themeOption)}
         </optgroup>
         <optgroup label="Available themes">
-          {themes
+          {themeNames
             .filter((theme) => !visibleThemes.some((t) => t === theme))
             .map(themeOption)}
         </optgroup>
       </Fragment>
     ) : (
-      themes.map(themeOption)
+      themeNames.map(themeOption)
     );
 
   return (

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -20,11 +20,10 @@ import ShareIcon from '../icons/ShareIcon';
 import * as styles from './Toolbar.css';
 
 interface Props {
-  themes: PlayroomProps['themes'];
   snippets: PlayroomProps['snippets'];
 }
 
-export default ({ themes: allThemes, snippets }: Props) => {
+export default ({ snippets }: Props) => {
   const [
     {
       visibleThemes = [],
@@ -187,13 +186,9 @@ export default ({ themes: allThemes, snippets }: Props) => {
               />
             )}
 
-            {lastActivePanel === 'frames' && (
-              <FramesPanel availableThemes={allThemes} />
-            )}
+            {lastActivePanel === 'frames' && <FramesPanel />}
 
-            {lastActivePanel === 'preview' && (
-              <PreviewPanel themes={allThemes} visibleThemes={visibleThemes} />
-            )}
+            {lastActivePanel === 'preview' && <PreviewPanel />}
 
             {lastActivePanel === 'settings' && <SettingsPanel />}
           </div>

--- a/src/configModules/themes.ts
+++ b/src/configModules/themes.ts
@@ -1,4 +1,6 @@
 import * as themes from '__PLAYROOM_ALIAS__THEMES__';
 
+export const themeNames = Object.keys(themes);
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 export default themes as typeof import('__PLAYROOM_ALIAS__THEMES__').default;

--- a/src/entries/index.tsx
+++ b/src/entries/index.tsx
@@ -3,7 +3,6 @@ import faviconPath from '../../images/favicon.png';
 import Playroom from '../components/Playroom/Playroom';
 import components from '../configModules/components';
 import snippets from '../configModules/snippets';
-import themes from '../configModules/themes';
 import { StoreProvider } from '../contexts/StoreContext';
 import { renderElement } from '../render';
 
@@ -19,11 +18,9 @@ if (selectedElement) {
   selectedElement.setAttribute('href', favicon);
 }
 
-const themeNames = Object.keys(themes);
-
 renderElement(
-  <StoreProvider themes={themeNames}>
-    <Playroom components={components} themes={themeNames} snippets={snippets} />
+  <StoreProvider>
+    <Playroom components={components} snippets={snippets} />
   </StoreProvider>,
   outlet
 );


### PR DESCRIPTION
Expose `themeNames` via the `themes` config module, rather than prop-drilling.