### PR TITLE
refactor: Consume `snippets` via config module

### DIFF
--- a/src/components/Playroom/Playroom.tsx
+++ b/src/components/Playroom/Playroom.tsx
@@ -11,7 +11,6 @@ import {
 import { Helmet } from 'react-helmet';
 import { useDebouncedCallback } from 'use-debounce';
 
-import type { Snippets } from '../../../utils';
 import { StoreContext, type EditorPosition } from '../../contexts/StoreContext';
 import componentsToHints from '../../utils/componentsToHints';
 import { Box } from '../Box/Box';
@@ -65,10 +64,9 @@ const getTitle = (title: string | undefined) => {
 
 export interface PlayroomProps {
   components: Record<string, ComponentType<any>>;
-  snippets: Snippets;
 }
 
-export default ({ components, snippets }: PlayroomProps) => {
+export default ({ components }: PlayroomProps) => {
   const [
     {
       editorPosition,
@@ -144,7 +142,7 @@ export default ({ components, snippets }: PlayroomProps) => {
         <StatusMessage />
       </div>
       <div className={styles.toolbarContainer}>
-        <Toolbar snippets={snippets} />
+        <Toolbar />
       </div>
     </Fragment>
   );

--- a/src/components/Snippets/Snippets.tsx
+++ b/src/components/Snippets/Snippets.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, useMemo } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 
 import type { Snippet } from '../../../utils';
-import type { PlayroomProps } from '../Playroom/Playroom';
+import snippets from '../../configModules/snippets';
 import { Stack } from '../Stack/Stack';
 import { Text } from '../Text/Text';
 
@@ -16,7 +16,6 @@ type HighlightIndex = number | null;
 type ReturnedSnippet = Snippet | null;
 interface Props {
   isOpen: boolean;
-  snippets: PlayroomProps['snippets'];
   onHighlight?: (snippet: ReturnedSnippet) => void;
   onClose?: (snippet: ReturnedSnippet) => void;
 }
@@ -27,7 +26,7 @@ function getSnippetId(snippet: Snippet, index: number) {
   return `${snippet.group}_${snippet.name}_${index}`;
 }
 
-const options = {
+const fuse = new Fuse(snippets, {
   threshold: 0.3,
   keys: [
     {
@@ -39,9 +38,9 @@ const options = {
       weight: 1,
     },
   ],
-};
+});
 
-export default ({ isOpen, snippets, onHighlight, onClose }: Props) => {
+export default ({ isOpen, onHighlight, onClose }: Props) => {
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [highlightedIndex, setHighlightedIndex] =
     useState<HighlightIndex>(null);
@@ -49,14 +48,12 @@ export default ({ isOpen, snippets, onHighlight, onClose }: Props) => {
   const listEl = useRef<HTMLUListElement | null>(null);
   const highlightedEl = useRef<HTMLLIElement | null>(null);
 
-  const fuse = useMemo(() => new Fuse(snippets, options), [snippets]);
-
   const filteredSnippets = useMemo(
     () =>
       searchTerm
         ? fuse.search(searchTerm).map((result) => result.item)
         : snippets,
-    [fuse, searchTerm, snippets]
+    [searchTerm]
   );
 
   const closeHandler = (returnValue: ReturnedSnippet) => {

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -2,10 +2,10 @@ import clsx from 'clsx';
 import { useContext, useState, useCallback, useEffect, useRef } from 'react';
 import { CSSTransition } from 'react-transition-group';
 
+import snippets from '../../configModules/snippets';
 import { StoreContext } from '../../contexts/StoreContext';
 import { isMac } from '../../utils/formatting';
 import FramesPanel from '../FramesPanel/FramesPanel';
-import type { PlayroomProps } from '../Playroom/Playroom';
 import PreviewPanel from '../PreviewPanel/PreviewPanel';
 import SettingsPanel from '../SettingsPanel/SettingsPanel';
 import Snippets from '../Snippets/Snippets';
@@ -19,11 +19,7 @@ import ShareIcon from '../icons/ShareIcon';
 
 import * as styles from './Toolbar.css';
 
-interface Props {
-  snippets: PlayroomProps['snippets'];
-}
-
-export default ({ snippets }: Props) => {
+export default () => {
   const [
     {
       visibleThemes = [],
@@ -166,7 +162,6 @@ export default ({ snippets }: Props) => {
             {lastActivePanel === 'snippets' && (
               <Snippets
                 isOpen={isOpen}
-                snippets={snippets}
                 onHighlight={(snippet) => {
                   dispatch({
                     type: 'previewSnippet',

--- a/src/entries/index.tsx
+++ b/src/entries/index.tsx
@@ -2,7 +2,6 @@ import faviconInvertedPath from '../../images/favicon-inverted.png';
 import faviconPath from '../../images/favicon.png';
 import Playroom from '../components/Playroom/Playroom';
 import components from '../configModules/components';
-import snippets from '../configModules/snippets';
 import { StoreProvider } from '../contexts/StoreContext';
 import { renderElement } from '../render';
 
@@ -20,7 +19,7 @@ if (selectedElement) {
 
 renderElement(
   <StoreProvider>
-    <Playroom components={components} snippets={snippets} />
+    <Playroom components={components} />
   </StoreProvider>,
   outlet
 );


### PR DESCRIPTION
Consume `snippets` via the config module, rather than prop-drilling.