### PR TITLE
refactor: Consume `components` via config module

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,0 +1,13 @@
+export default {
+  moduleNameMapper: {
+    // Stubbing to basic config. Unit tests should not rely on
+    // a Playroom config object, instead test private functions
+    // that accept dependencies. See `componentsToHints` test.
+    __PLAYROOM_ALIAS__COMPONENTS__:
+      '<rootDir>/cypress/projects/basic/components.js',
+  },
+  globals: {
+    // Same as `__PLAYROOM_ALIAS__COMPONENTS__` above.
+    __PLAYROOM_GLOBAL__STATIC_TYPES__: {},
+  },
+};

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -7,6 +7,7 @@ import 'codemirror/theme/neo.css';
 
 import { type CursorPosition, StoreContext } from '../../contexts/StoreContext';
 import { validateCode } from '../../utils/compileJsx';
+import { hints } from '../../utils/componentsToHints';
 import { formatCode as format, isMac } from '../../utils/formatting';
 
 import { UnControlled as ReactCodeMirror } from './CodeMirror2';
@@ -59,16 +60,11 @@ const validateCodeInEditor = (editorInstance: Editor, code: string) => {
   }
 };
 
-interface Hint {
-  attrs: Record<string, any>;
-}
-
 interface Props {
   code: string;
   onChange: (code: string) => void;
   editorHidden: boolean;
   previewCode?: string;
-  hints?: Record<string, Hint>;
 }
 
 export const CodeEditor = ({
@@ -76,7 +72,6 @@ export const CodeEditor = ({
   editorHidden,
   onChange,
   previewCode,
-  hints,
 }: Props) => {
   const editorInstanceRef = useRef<Editor | null>(null);
   const insertionPointRef = useRef<ReturnType<Editor['addLineClass']> | null>(

--- a/src/components/Playroom/Playroom.tsx
+++ b/src/components/Playroom/Playroom.tsx
@@ -1,18 +1,11 @@
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import clsx from 'clsx';
 import { Resizable } from 're-resizable';
-import {
-  useContext,
-  type ComponentType,
-  Fragment,
-  useState,
-  useEffect,
-} from 'react';
+import { useContext, Fragment, useState, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { useDebouncedCallback } from 'use-debounce';
 
 import { StoreContext, type EditorPosition } from '../../contexts/StoreContext';
-import componentsToHints from '../../utils/componentsToHints';
 import { Box } from '../Box/Box';
 import { CodeEditor } from '../CodeEditor/CodeEditor';
 import Frames from '../Frames/Frames';
@@ -23,8 +16,6 @@ import { ANIMATION_TIMEOUT } from '../constants';
 import ChevronIcon from '../icons/ChevronIcon';
 
 import * as styles from './Playroom.css';
-
-const staticTypes = __PLAYROOM_GLOBAL__STATIC_TYPES__;
 
 const resizableConfig = (position: EditorPosition = 'bottom') => ({
   top: position === 'bottom',
@@ -62,11 +53,7 @@ const getTitle = (title: string | undefined) => {
   return 'Playroom';
 };
 
-export interface PlayroomProps {
-  components: Record<string, ComponentType<any>>;
-}
-
-export default ({ components }: PlayroomProps) => {
+export default () => {
   const [
     {
       editorPosition,
@@ -137,7 +124,6 @@ export default ({ components }: PlayroomProps) => {
             dispatch({ type: 'updateCode', payload: { code: newCode } })
           }
           previewCode={previewEditorCode}
-          hints={componentsToHints(components, staticTypes)}
         />
         <StatusMessage />
       </div>

--- a/src/entries/index.tsx
+++ b/src/entries/index.tsx
@@ -1,7 +1,6 @@
 import faviconInvertedPath from '../../images/favicon-inverted.png';
 import faviconPath from '../../images/favicon.png';
 import Playroom from '../components/Playroom/Playroom';
-import components from '../configModules/components';
 import { StoreProvider } from '../contexts/StoreContext';
 import { renderElement } from '../render';
 
@@ -19,7 +18,7 @@ if (selectedElement) {
 
 renderElement(
   <StoreProvider>
-    <Playroom components={components} />
+    <Playroom />
   </StoreProvider>,
   outlet
 );

--- a/src/utils/componentsToHints.test.ts
+++ b/src/utils/componentsToHints.test.ts
@@ -6,7 +6,7 @@ Todo - revisit componentsToHints to optimise
 */
 
 // eslint-disable-next-line import-x/order
-import componentsToHints from './componentsToHints';
+import { __private_create_hints } from './componentsToHints';
 
 // @ts-expect-error
 import * as PropTypeComponents from '../../cypress/projects/themed/components';
@@ -14,7 +14,7 @@ import * as TypeScriptComponents from '../../cypress/projects/typescript/compone
 
 describe('componentsToHints', () => {
   it('should support javascript components with proptypes', () => {
-    const result = componentsToHints({
+    const result = __private_create_hints({
       Bar: PropTypeComponents.Bar,
       Foo: PropTypeComponents.Foo,
     });
@@ -42,7 +42,7 @@ describe('componentsToHints', () => {
   });
 
   it('should support typescript components when provided with type data', () => {
-    const result = componentsToHints(
+    const result = __private_create_hints(
       {
         Bar: TypeScriptComponents.Bar,
         Foo: TypeScriptComponents.Foo,


### PR DESCRIPTION
Consume `components` via the config module, rather than prop-drilling.