### PR TITLE
Migrate top-level layout to CSS Grid

### DIFF
--- a/.changeset/dull-kiwis-bake.md
+++ b/.changeset/dull-kiwis-bake.md
@@ -1,0 +1,9 @@
+---
+'playroom': patch
+---
+
+Migrate top-level layout to CSS Grid
+
+Refactor the top-level layout of Playroom to use CSS Grid in preparation for upcoming UI features.
+
+Additionally, migrate away from `re-resizable` package for panel resizing in favour of a custom implementation to improve UI performance.

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "portfinder": "^1.0.32",
     "prettier": "^2.8.1",
     "prop-types": "^15.8.1",
-    "re-resizable": "^6.11.2",
     "react-docgen-typescript": "^2.2.2",
     "react-error-boundary": "^4.0.13",
     "react-helmet": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,9 +116,6 @@ importers:
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
-      re-resizable:
-        specifier: ^6.11.2
-        version: 6.11.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-docgen-typescript:
         specifier: ^2.2.2
         version: 2.2.2(typescript@5.8.2)
@@ -4677,12 +4674,6 @@ packages:
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
-
-  re-resizable@6.11.2:
-    resolution: {integrity: sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==}
-    peerDependencies:
-      react: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-docgen-typescript@2.2.2:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
@@ -11063,11 +11054,6 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-
-  re-resizable@6.11.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
-    dependencies:
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
 
   react-docgen-typescript@2.2.2(typescript@5.8.2):
     dependencies:

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -73,6 +73,7 @@ export const CodeEditor = ({
   onChange,
   previewCode,
 }: Props) => {
+  const mounted = useRef(false);
   const editorInstanceRef = useRef<Editor | null>(null);
   const insertionPointRef = useRef<ReturnType<Editor['addLineClass']> | null>(
     null
@@ -161,9 +162,10 @@ export const CodeEditor = ({
   useEffect(() => {
     if (editorInstanceRef.current) {
       if (
-        editorInstanceRef.current.hasFocus() ||
-        code === editorInstanceRef.current.getValue() ||
-        previewCode
+        mounted.current &&
+        (editorInstanceRef.current.hasFocus() ||
+          code === editorInstanceRef.current.getValue() ||
+          previewCode)
       ) {
         return;
       }
@@ -172,14 +174,7 @@ export const CodeEditor = ({
     }
   }, [code, previewCode]);
 
-  const mounted = useRef(false);
-
   useEffect(() => {
-    if (!mounted.current) {
-      mounted.current = true;
-      return;
-    }
-
     if (editorInstanceRef.current && !editorInstanceRef.current.hasFocus()) {
       setCursorPosition(cursorPosition);
     }
@@ -220,6 +215,10 @@ export const CodeEditor = ({
         if (!editorHidden) {
           setCursorPosition(cursorPosition);
         }
+        // Set mounted flag on next tick
+        setTimeout(() => {
+          mounted.current = true;
+        }, 1);
       }}
       onChange={(editorInstance, data, newCode) => {
         if (editorInstance.hasFocus() && !previewCode) {

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -215,7 +215,11 @@ export const CodeEditor = ({
         if (!editorHidden) {
           setCursorPosition(cursorPosition);
         }
-        // Set mounted flag on next tick
+        /**
+         * This workaround delays the setting of the mounted flag. It allows
+         * the behaviours wired up via `useEffect` to complete without being
+         * interrupted by change or focus events.
+         */
         setTimeout(() => {
           mounted.current = true;
         }, 1);

--- a/src/components/Playroom/Playroom.css.ts
+++ b/src/components/Playroom/Playroom.css.ts
@@ -7,7 +7,11 @@ import {
 } from '@vanilla-extract/css';
 
 import { space, comma, newline } from '../../css/delimiters';
-import { toolbarItemCount, toolbarOpenSize } from '../constants';
+import {
+  ANIMATION_DURATION_SLOW,
+  toolbarItemCount,
+  toolbarOpenSize,
+} from '../constants';
 
 import { sprinkles, colorPaletteVars } from '../../css/sprinkles.css';
 import { vars } from '../../css/vars.css';
@@ -52,11 +56,10 @@ export const root = style([
   },
 ]);
 
-export const toggleEditorDuration = 300;
 export const editorTransition = style({
   transition: comma(
-    `grid-template-columns ${toggleEditorDuration}ms ease`,
-    `grid-template-rows ${toggleEditorDuration}ms ease`
+    `grid-template-columns ${ANIMATION_DURATION_SLOW}ms ease`,
+    `grid-template-rows ${ANIMATION_DURATION_SLOW}ms ease`
   ),
 });
 

--- a/src/components/Playroom/Playroom.css.ts
+++ b/src/components/Playroom/Playroom.css.ts
@@ -49,16 +49,16 @@ export const root = style([
     gridTemplateColumns: space('1fr', fallbackVar(rightEditorWidth, '0px')),
     gridTemplateRows: space('auto', fallbackVar(bottomEditorHeight, '0px')),
     willChange: comma('grid-template-columns', 'grid-template-rows'),
-    selectors: {
-      [`&:not(${resizing})`]: {
-        transition: comma(
-          'grid-template-columns 300ms ease',
-          'grid-template-rows 300ms ease'
-        ),
-      },
-    },
   },
 ]);
+
+export const toggleEditorDuration = 300;
+export const editorTransition = style({
+  transition: comma(
+    `grid-template-columns ${toggleEditorDuration}ms ease`,
+    `grid-template-rows ${toggleEditorDuration}ms ease`
+  ),
+});
 
 export const editorPosition = styleVariants({
   bottom: [

--- a/src/components/Playroom/Playroom.tsx
+++ b/src/components/Playroom/Playroom.tsx
@@ -14,6 +14,7 @@ import { CodeEditor } from '../CodeEditor/CodeEditor';
 import Frames from '../Frames/Frames';
 import { StatusMessage } from '../StatusMessage/StatusMessage';
 import Toolbar from '../Toolbar/Toolbar';
+import { ANIMATION_DURATION_SLOW } from '../constants';
 import ChevronIcon from '../icons/ChevronIcon';
 
 import { ResizeHandle } from './ResizeHandle';
@@ -76,7 +77,7 @@ export default () => {
   useEffect(() => {
     transitionTimeoutRef.current = setTimeout(
       () => setLastEditorHidden(editorHidden),
-      styles.toggleEditorDuration
+      ANIMATION_DURATION_SLOW
     );
 
     return () => {

--- a/src/components/Playroom/Playroom.tsx
+++ b/src/components/Playroom/Playroom.tsx
@@ -1,9 +1,6 @@
 import { assignInlineVars } from '@vanilla-extract/dynamic';
-import clsx from 'clsx';
-import { Resizable } from 're-resizable';
-import { useContext, Fragment, useState, useEffect } from 'react';
+import { type ComponentProps, useContext, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet';
-import { useDebouncedCallback } from 'use-debounce';
 
 import { StoreContext, type EditorPosition } from '../../contexts/StoreContext';
 import { Box } from '../Box/Box';
@@ -11,21 +8,11 @@ import { CodeEditor } from '../CodeEditor/CodeEditor';
 import Frames from '../Frames/Frames';
 import { StatusMessage } from '../StatusMessage/StatusMessage';
 import Toolbar from '../Toolbar/Toolbar';
-import { ANIMATION_TIMEOUT } from '../constants';
 import ChevronIcon from '../icons/ChevronIcon';
 
-import * as styles from './Playroom.css';
+import { ResizeHandle } from './ResizeHandle';
 
-const resizableConfig = (position: EditorPosition = 'bottom') => ({
-  top: position === 'bottom',
-  right: false,
-  bottom: false,
-  left: position === 'right',
-  topRight: false,
-  bottomRight: false,
-  bottomLeft: false,
-  topLeft: false,
-});
+import * as styles from './Playroom.css';
 
 const resolveDirection = (
   editorPosition: EditorPosition,
@@ -52,6 +39,14 @@ const getTitle = (title: string | undefined) => {
   return 'Playroom';
 };
 
+const resizeHandlePosition: Record<
+  EditorPosition,
+  ComponentProps<typeof ResizeHandle>['position']
+> = {
+  bottom: 'top',
+  right: 'left',
+} as const;
+
 export default () => {
   const [
     {
@@ -67,83 +62,28 @@ export default () => {
     },
     dispatch,
   ] = useContext(StoreContext);
-
-  // This is necessary because this updates slightly after editorHidden updates,
-  // not at the same time
-  const [editorVisibilityAfterTransition, setEditorVisibilityAfterTransition] =
-    useState<boolean>(editorHidden);
-
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      setEditorVisibilityAfterTransition(editorHidden);
-    }, ANIMATION_TIMEOUT);
-
-    return () => clearTimeout(timeoutId);
-  }, [editorHidden]);
-
-  const editorAvailable = !editorHidden && !editorVisibilityAfterTransition;
-
-  const displayedTitle = getTitle(title);
-
-  const updateEditorSize = useDebouncedCallback(
-    ({
-      isVerticalEditor,
-      offsetWidth,
-      offsetHeight,
-    }: {
-      isVerticalEditor: boolean;
-      offsetHeight: number;
-      offsetWidth: number;
-    }) => {
-      dispatch({
-        type: isVerticalEditor ? 'updateEditorWidth' : 'updateEditorHeight',
-        payload: { size: isVerticalEditor ? offsetWidth : offsetHeight },
-      });
-    },
-    1
-  );
+  const [resizing, setResizing] = useState(false);
+  const editorRef = useRef<HTMLElement | null>(null);
 
   if (!ready) {
     return null;
   }
 
-  const codeEditor = (
-    <Fragment>
-      <div inert={editorHidden} className={styles.editorContainer}>
-        <CodeEditor
-          code={code}
-          editorHidden={editorHidden}
-          onChange={(newCode: string) =>
-            dispatch({ type: 'updateCode', payload: { code: newCode } })
-          }
-          previewCode={previewEditorCode}
-        />
-        <StatusMessage />
-      </div>
-      <div className={styles.toolbarContainer}>
-        <Toolbar />
-      </div>
-    </Fragment>
-  );
-
   const isVerticalEditor = editorPosition === 'right';
-  const isHorizontalEditor = editorPosition === 'bottom';
-
-  const sizeStyles = {
-    height: isHorizontalEditor ? editorHeight : 'auto',
-    width: isVerticalEditor ? editorWidth : 'auto',
-  };
-  const hiddenSizeStyles = {
-    height: isHorizontalEditor ? 0 : 'auto',
-    width: isVerticalEditor ? 0 : 'auto',
-  };
+  const editorSize = isVerticalEditor ? editorWidth : editorHeight;
+  const displayedTitle = getTitle(title);
 
   return (
     <Box
-      display="flex"
-      height="viewport"
-      width="viewport"
-      className={styles.root[editorPosition]}
+      component="main"
+      className={{
+        [styles.root]: true,
+        [styles.editorPosition[editorPosition]]: true,
+        [styles.resizing]: resizing,
+      }}
+      style={assignInlineVars({
+        [styles.editorSize]: editorHidden ? undefined : editorSize,
+      })}
     >
       {title === undefined ? null : (
         <Helmet>
@@ -151,13 +91,11 @@ export default () => {
         </Helmet>
       )}
 
-      <Box position="relative" flexGrow={1} className={styles.previewContainer}>
-        <Frames code={previewRenderCode || code} />
-        <div
-          className={clsx(styles.toggleEditorContainer, {
-            [styles.isBottom]: isHorizontalEditor,
-          })}
-        >
+      <Box position="relative" className={styles.frames}>
+        <Box className={styles.framesContainer}>
+          <Frames code={previewRenderCode || code} />
+        </Box>
+        <Box className={styles.toggleEditorContainer}>
           <button
             className={styles.toggleEditorButton}
             title={`${editorHidden ? 'Show' : 'Hide'} the editor`}
@@ -170,44 +108,52 @@ export default () => {
               direction={resolveDirection(editorPosition, editorHidden)}
             />
           </button>
+        </Box>
+      </Box>
+
+      <Box
+        position="relative"
+        className={styles.editor}
+        inert={editorHidden}
+        ref={editorRef}
+      >
+        <div className={styles.editorContainer}>
+          <ResizeHandle
+            ref={editorRef}
+            position={resizeHandlePosition[editorPosition]}
+            onResize={(newValue) => {
+              dispatch({
+                type: isVerticalEditor
+                  ? 'updateEditorWidth'
+                  : 'updateEditorHeight',
+                payload: { size: newValue },
+              });
+            }}
+            onResizeStart={() => setResizing(true)}
+            onResizeEnd={(endValue) => {
+              setResizing(false);
+              dispatch({
+                type: isVerticalEditor
+                  ? 'updateEditorWidth'
+                  : 'updateEditorHeight',
+                payload: { size: endValue },
+              });
+            }}
+          />
+          <CodeEditor
+            code={code}
+            editorHidden={editorHidden}
+            onChange={(newCode: string) =>
+              dispatch({ type: 'updateCode', payload: { code: newCode } })
+            }
+            previewCode={previewEditorCode}
+          />
+          <StatusMessage />
+          <div className={styles.toolbarContainer}>
+            <Toolbar />
+          </div>
         </div>
       </Box>
-      <Resizable
-        style={assignInlineVars({
-          [styles.editorSize]:
-            editorPosition === 'right' ? editorWidth : editorHeight,
-        })}
-        className={clsx({
-          [styles.resizable]: true,
-          [styles.resizableSize[editorPosition]]: !editorHidden,
-          [styles.resizableUnavailable]: !editorAvailable,
-          [styles.resizableAvailable[editorPosition]]: editorAvailable,
-        })}
-        defaultSize={sizeStyles}
-        size={editorHidden ? hiddenSizeStyles : sizeStyles}
-        onResize={(_event, _direction, { offsetWidth, offsetHeight }) => {
-          updateEditorSize({ isVerticalEditor, offsetWidth, offsetHeight });
-        }}
-        onResizeStart={(_event, _direction, _refToElement) => {
-          _refToElement.classList.remove(styles.resizableSize[editorPosition]);
-        }}
-        onResizeStop={(_event, _direction, _refToElement) => {
-          _refToElement.classList.add(styles.resizableSize[editorPosition]);
-        }}
-        enable={resizableConfig(editorPosition)}
-        /*
-         * Ensures resizable handles are stacked above the `codeEditor` component.
-         * By default, handles are stacked below the editor as introduced in:
-         * https://github.com/bokuweb/re-resizable/pull/827
-         */
-        handleStyles={
-          editorPosition === 'bottom'
-            ? { top: { zIndex: 1 } }
-            : { left: { zIndex: 1 } }
-        }
-      >
-        {codeEditor}
-      </Resizable>
     </Box>
   );
 };

--- a/src/components/Playroom/ResizeHandle.css.ts
+++ b/src/components/Playroom/ResizeHandle.css.ts
@@ -1,0 +1,73 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+
+import { colorPaletteVars, sprinkles } from '../../css/sprinkles.css';
+
+const thickness = 8;
+const length = 70;
+
+// Separate style applied to the container AND the body during resize.
+export const resizeCursor = styleVariants({
+  horizontal: {
+    cursor: 'row-resize',
+  },
+  vertical: {
+    cursor: 'col-resize',
+  },
+});
+
+const containerCommon = sprinkles({
+  position: 'absolute',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  zIndex: 1,
+});
+
+export const resizeContainer = styleVariants({
+  horizontal: [
+    resizeCursor.horizontal,
+    containerCommon,
+    sprinkles({
+      width: 'full',
+      paddingTop: 'small',
+    }),
+  ],
+  vertical: [
+    resizeCursor.vertical,
+    containerCommon,
+    sprinkles({
+      height: 'full',
+      paddingX: 'small',
+    }),
+  ],
+});
+
+export const right = sprinkles({ right: 0 });
+export const left = sprinkles({ left: 0 });
+
+const handleCommon = style([
+  sprinkles({
+    borderRadius: 'large',
+    pointerEvents: 'none',
+  }),
+  {
+    background: colorPaletteVars.background.neutral,
+  },
+]);
+
+export const handle = styleVariants({
+  horizontal: [
+    handleCommon,
+    {
+      width: length,
+      height: thickness,
+    },
+  ],
+  vertical: [
+    handleCommon,
+    {
+      width: thickness,
+      height: length,
+    },
+  ],
+});

--- a/src/components/Playroom/ResizeHandle.css.ts
+++ b/src/components/Playroom/ResizeHandle.css.ts
@@ -2,7 +2,7 @@ import { style, styleVariants } from '@vanilla-extract/css';
 
 import { colorPaletteVars, sprinkles } from '../../css/sprinkles.css';
 
-const thickness = 8;
+const thickness = 4;
 const length = 70;
 
 // Separate style applied to the container AND the body during resize.

--- a/src/components/Playroom/ResizeHandle.tsx
+++ b/src/components/Playroom/ResizeHandle.tsx
@@ -49,9 +49,7 @@ export const ResizeHandle = ({
     const startPosition = resolvePosition(event.nativeEvent, pagePos);
     const startSize = ref.current?.[elementSize] ?? 0;
 
-    if (typeof onResizeStart === 'function') {
-      onResizeStart(startSize);
-    }
+    onResizeStart?.(startSize);
     document.body.classList.add(styles.resizeCursor[direction]);
 
     const moveHandler: NativeTouchOrMouseMove = (moveEvent) => {
@@ -61,10 +59,8 @@ export const ResizeHandle = ({
     };
 
     const stopHandler = () => {
-      if (typeof onResizeEnd === 'function') {
-        const endSize = ref.current?.[elementSize] ?? 0;
-        onResizeEnd(endSize);
-      }
+      const endSize = ref.current?.[elementSize] ?? 0;
+      onResizeEnd?.(endSize);
       document.body.classList.remove(styles.resizeCursor[direction]);
 
       window.removeEventListener('mousemove', moveHandler);

--- a/src/components/Playroom/ResizeHandle.tsx
+++ b/src/components/Playroom/ResizeHandle.tsx
@@ -1,0 +1,95 @@
+import type { RefObject } from 'react';
+
+import { Box } from '../Box/Box';
+
+import * as styles from './ResizeHandle.css';
+
+type NativeTouchOrMouseMove = Parameters<
+  typeof window.addEventListener<'mousemove' | 'touchmove'>
+>[1];
+
+const resolvePosition = (
+  event: MouseEvent | TouchEvent,
+  pagePos: 'pageX' | 'pageY'
+) => {
+  let position = 0;
+
+  if ('touches' in event && event.touches.length > 0) {
+    position = event.touches[0][pagePos];
+  } else if ('pageX' in event) {
+    position = event[pagePos];
+  }
+
+  return position;
+};
+
+export const ResizeHandle = ({
+  position,
+  ref,
+  onResize,
+  onResizeStart,
+  onResizeEnd,
+}: {
+  position: 'top' | 'right' | 'left';
+  flip?: boolean;
+  ref: RefObject<HTMLElement | null>;
+  onResize: (newValue: number) => void;
+  onResizeStart?: (startValue: number) => void;
+  onResizeEnd?: (endValue: number) => void;
+}) => {
+  const isVertical = position !== 'top';
+  const modifier = position === 'right' ? -1 : 1;
+  const direction = isVertical ? 'vertical' : 'horizontal';
+  const pagePos = isVertical ? 'pageX' : 'pageY';
+  const elementSize = isVertical ? 'offsetWidth' : 'offsetHeight';
+
+  const startHandler = (
+    event: React.MouseEvent<HTMLElement> | React.TouchEvent<HTMLElement>
+  ) => {
+    const startPosition = resolvePosition(event.nativeEvent, pagePos);
+    const startSize = ref.current?.[elementSize] ?? 0;
+
+    if (typeof onResizeStart === 'function') {
+      onResizeStart(startSize);
+    }
+    document.body.classList.add(styles.resizeCursor[direction]);
+
+    const moveHandler: NativeTouchOrMouseMove = (moveEvent) => {
+      const movePosition = resolvePosition(moveEvent, pagePos);
+      const delta = movePosition - startPosition;
+      onResize(startSize - delta * modifier);
+    };
+
+    const stopHandler = () => {
+      if (typeof onResizeEnd === 'function') {
+        const endSize = ref.current?.[elementSize] ?? 0;
+        onResizeEnd(endSize);
+      }
+      document.body.classList.remove(styles.resizeCursor[direction]);
+
+      window.removeEventListener('mousemove', moveHandler);
+      window.removeEventListener('touchmove', moveHandler);
+      window.removeEventListener('mouseup', stopHandler);
+      window.removeEventListener('touchend', stopHandler);
+    };
+
+    window.addEventListener('mousemove', moveHandler);
+    window.addEventListener('touchmove', moveHandler);
+    window.addEventListener('mouseup', stopHandler);
+    window.addEventListener('touchend', stopHandler);
+  };
+
+  return (
+    <Box
+      onTouchStart={startHandler}
+      onMouseDown={startHandler}
+      className={{
+        [styles.resizeContainer[direction]]: true,
+        [styles.right]: position === 'right',
+        [styles.left]: position === 'left',
+      }}
+    >
+      <Box className={styles.handle[direction]} />
+    </Box>
+  );
+};

--- a/src/components/Playroom/ResizeHandle.tsx
+++ b/src/components/Playroom/ResizeHandle.tsx
@@ -82,7 +82,12 @@ export const ResizeHandle = ({
   return (
     <Box
       onTouchStart={startHandler}
-      onMouseDown={startHandler}
+      onMouseDown={(event) => {
+        // Only initiate resize on left click
+        if (event.button === 0) {
+          startHandler(event);
+        }
+      }}
       className={{
         [styles.resizeContainer[direction]]: true,
         [styles.right]: position === 'right',

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -10,7 +10,7 @@ import PreviewPanel from '../PreviewPanel/PreviewPanel';
 import SettingsPanel from '../SettingsPanel/SettingsPanel';
 import Snippets from '../Snippets/Snippets';
 import ToolbarItem from '../ToolbarItem/ToolbarItem';
-import { ANIMATION_TIMEOUT } from '../constants';
+import { ANIMATION_DURATION_SLOW } from '../constants';
 import AddIcon from '../icons/AddIcon';
 import FramesIcon from '../icons/FramesIcon';
 import PlayIcon from '../icons/PlayIcon';
@@ -152,7 +152,7 @@ export default () => {
         <CSSTransition
           in={isOpen}
           nodeRef={panelRef}
-          timeout={ANIMATION_TIMEOUT}
+          timeout={ANIMATION_DURATION_SLOW}
           classNames={styles.transitionStyles}
           mountOnEnter
           unmountOnExit

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -1,4 +1,4 @@
-export const ANIMATION_TIMEOUT = 300;
+export const ANIMATION_DURATION_SLOW = 300;
 
 export const toolbarItemCount = 5;
 export const toolbarItemSize = 60;

--- a/src/css/delimiters.ts
+++ b/src/css/delimiters.ts
@@ -1,0 +1,3 @@
+export const space = (...strings: string[]) => strings.join(' ');
+export const comma = (...strings: string[]) => strings.join(', ');
+export const newline = (...strings: string[]) => strings.join('\n ');

--- a/src/css/delimiters.ts
+++ b/src/css/delimiters.ts
@@ -1,3 +1,3 @@
 export const space = (...strings: string[]) => strings.join(' ');
 export const comma = (...strings: string[]) => strings.join(', ');
-export const newline = (...strings: string[]) => strings.join('\n ');
+export const newline = (...strings: string[]) => strings.join('\n');

--- a/src/entries/frame.tsx
+++ b/src/entries/frame.tsx
@@ -3,9 +3,6 @@ import { SendErrorMessage } from '../components/Frame/frameMessaging';
 import { renderElement } from '../render';
 import { UrlParams } from '../utils/params';
 
-const outlet = document.createElement('div');
-document.body.appendChild(outlet);
-
 renderElement(
   <UrlParams>
     {({ code, themeName, theme }) => (
@@ -17,5 +14,5 @@ renderElement(
       />
     )}
   </UrlParams>,
-  outlet
+  document.body
 );

--- a/src/entries/index.tsx
+++ b/src/entries/index.tsx
@@ -4,9 +4,6 @@ import Playroom from '../components/Playroom/Playroom';
 import { StoreProvider } from '../contexts/StoreContext';
 import { renderElement } from '../render';
 
-const outlet = document.createElement('div');
-document.body.appendChild(outlet);
-
 const selectedElement = document.head.querySelector('link[rel="icon"]');
 const favicon = window.matchMedia('(prefers-color-scheme: dark)').matches
   ? faviconInvertedPath
@@ -20,5 +17,5 @@ renderElement(
   <StoreProvider>
     <Playroom />
   </StoreProvider>,
-  outlet
+  document.body
 );

--- a/src/entries/preview.tsx
+++ b/src/entries/preview.tsx
@@ -6,9 +6,6 @@ import { PreviewError } from '../components/Preview/PreviewError';
 import { renderElement } from '../render';
 import { UrlParams } from '../utils/params';
 
-const outlet = document.createElement('div');
-document.body.appendChild(outlet);
-
 const selectedElement = document.head.querySelector('link[rel="icon"]');
 const favicon = window.matchMedia('(prefers-color-scheme: dark)').matches
   ? faviconInvertedPath
@@ -33,5 +30,5 @@ renderElement(
       </Preview>
     )}
   </UrlParams>,
-  outlet
+  document.body
 );


### PR DESCRIPTION
Refactor the top-level layout of Playroom to use CSS Grid in preparation for upcoming UI features.

Additionally, migrate away from `re-resizable` package for panel resizing in favour of a custom implementation to improve UI performance.