### PR TITLE
Evaluate `scope` in the context of `FrameComponent`

### DIFF
--- a/.changeset/violet-eagles-work.md
+++ b/.changeset/violet-eagles-work.md
@@ -1,0 +1,8 @@
+---
+'playroom': patch
+---
+
+Evaluate `scope` in the context of `FrameComponent`
+
+Ensure the provided `scope` is evaluated within the context of the provided `FrameComponent`.
+This was a regression in the recent refactor, and fixing it enables usage of React Context by wrapping a Provider in the `FrameComponent` and retrieving its value via `scope`.

--- a/cypress/e2e/scope.cy.ts
+++ b/cypress/e2e/scope.cy.ts
@@ -10,7 +10,7 @@ describe('useScope', () => {
   });
 
   it('works', () => {
-    typeCode('{{}hello()} {{}world()}');
-    assertFirstFrameContains('HELLO WORLD');
+    typeCode('{{}hello()} {{}world()} {{}contextValue}');
+    assertFirstFrameContains('HELLO WORLD CONTEXT_VALUE');
   });
 });

--- a/cypress/projects/basic/FrameComponent.js
+++ b/cypress/projects/basic/FrameComponent.js
@@ -1,0 +1,5 @@
+import { TestContext } from './context';
+
+export default ({ children }) => (
+  <TestContext.Provider value="CONTEXT_VALUE">{children}</TestContext.Provider>
+);

--- a/cypress/projects/basic/context.js
+++ b/cypress/projects/basic/context.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const TestContext = createContext(null);

--- a/cypress/projects/basic/playroom.config.js
+++ b/cypress/projects/basic/playroom.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   components: './components',
+  frameComponent: './FrameComponent',
   scope: './useScope',
   snippets: './snippets',
   outputPath: './dist',

--- a/cypress/projects/basic/useScope.js
+++ b/cypress/projects/basic/useScope.js
@@ -1,4 +1,13 @@
-export default () => ({
-  hello: () => 'HELLO',
-  world: () => 'WORLD',
-});
+import { useContext } from 'react';
+
+import { TestContext } from './context';
+
+export default () => {
+  const testContext = useContext(TestContext);
+
+  return {
+    hello: () => 'HELLO',
+    world: () => 'WORLD',
+    contextValue: testContext,
+  };
+};

--- a/src/components/RenderCode/RenderCode.tsx
+++ b/src/components/RenderCode/RenderCode.tsx
@@ -3,7 +3,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 // @ts-expect-error no types
 import scopeEval from 'scope-eval';
 
-import scope from '../../configModules/useScope';
+import buildScope from '../../configModules/useScope';
 
 interface Props {
   code: string;
@@ -23,7 +23,7 @@ const EvalCode = ({
     }
   }, [onSuccess]);
 
-  return scopeEval(code, scope);
+  return scopeEval(code, buildScope());
 };
 
 export default function RenderCode({ code, onError }: Props) {

--- a/src/configModules/useScope.ts
+++ b/src/configModules/useScope.ts
@@ -8,26 +8,28 @@ import {
 
 import components from './components';
 
-const userScope = {
-  ...(userScopeFromConfig() ?? {}),
-  ...components,
-};
+export default () => {
+  const userScope = {
+    ...(userScopeFromConfig() ?? {}),
+    ...components,
+  };
 
-if (ReactCreateElementPragma in userScope) {
-  throw new Error(
-    `'${ReactCreateElementPragma}' is used internally by Playroom and is not allowed in scope`
-  );
-}
+  if (ReactCreateElementPragma in userScope) {
+    throw new Error(
+      `'${ReactCreateElementPragma}' is used internally by Playroom and is not allowed in scope`
+    );
+  }
 
-if (ReactFragmentPragma in userScope) {
-  throw new Error(
-    `'${ReactFragmentPragma}' is used internally by Playroom and is not allowed in scope`
-  );
-}
+  if (ReactFragmentPragma in userScope) {
+    throw new Error(
+      `'${ReactFragmentPragma}' is used internally by Playroom and is not allowed in scope`
+    );
+  }
 
-export default {
-  ...userScope,
-  React,
-  [ReactCreateElementPragma]: createElement,
-  [ReactFragmentPragma]: Fragment,
+  return {
+    ...userScope,
+    React,
+    [ReactCreateElementPragma]: createElement,
+    [ReactFragmentPragma]: Fragment,
+  };
 };


### PR DESCRIPTION
Ensure the provided `scope` is evaluated within the context of the provided `FrameComponent`.

This was a regression in the recent refactor, and fixing it enables usage of React Context by wrapping a Provider in the `FrameComponent` and retrieving its value via `scope`.

Adding tests to prevent this in the future too.