### PR TITLE
Only hide share actions from header without code

### DIFF
--- a/.changeset/twelve-humans-ask.md
+++ b/.changeset/twelve-humans-ask.md
@@ -1,0 +1,10 @@
+---
+'playroom': patch
+---
+
+Only hide share actions from header without code
+
+The header actions in the top right are now available on page load.
+This enables the selection of frames and/or themes before any code is added to the editor.
+
+The share and preview actions are still hidden and revealed when code is entered into the editor.

--- a/src/components/Header/Header.css.ts
+++ b/src/components/Header/Header.css.ts
@@ -30,7 +30,6 @@ export const menuContainer = style({
 
 export const actionsGap = 'xsmall';
 
-export const actionsReady = style({});
 export const actionsContainer = style([
   sprinkles({
     display: 'flex',
@@ -46,8 +45,20 @@ export const actionsContainer = style([
         display: 'none',
       },
     },
+  },
+]);
+
+export const shareActionsReady = style({});
+export const shareActions = style([
+  sprinkles({
+    display: 'flex',
+    alignItems: 'center',
+    gap: actionsGap,
+    transition: 'fast',
+  }),
+  {
     selectors: {
-      [`&:not(${actionsReady})`]: {
+      [`&:not(${shareActionsReady})`]: {
         opacity: 0,
         transform: `translateX(${vars.space[actionsGap]})`,
         pointerEvents: 'none',

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -398,61 +398,64 @@ export const Header = () => {
       </div>
       <Title />
       <SharedTooltipContext>
-        <div
-          className={clsx({
-            [styles.actionsContainer]: true,
-            [styles.actionsReady]: hasCode,
-          })}
-        >
-          <div className={styles.segmentedGroup}>
-            <button
-              type="button"
-              className={styles.segmentedTextButton}
-              onClick={() => setShareOpen(true)}
-            >
-              <Text>Share</Text>
-            </button>
-            <Tooltip
-              label={copying ? 'Copied!' : 'Copy link'}
-              trigger={
-                <button
-                  type="button"
-                  aria-label="Copy link"
-                  className={styles.segmentedIconButton}
-                  onClick={() => onCopyClick(window.location.href)}
-                >
-                  {copying ? (
-                    <span className={styles.copyLinkSuccess}>
-                      <Check size={14} />
-                    </span>
-                  ) : (
-                    <Link size={14} />
-                  )}
-                </button>
-              }
-            />
-          </div>
+        <div className={styles.actionsContainer}>
+          <div
+            className={clsx({
+              [styles.shareActions]: true,
+              [styles.shareActionsReady]: hasCode,
+            })}
+            inert={!hasCode ? true : undefined}
+          >
+            <div className={styles.segmentedGroup}>
+              <button
+                type="button"
+                className={styles.segmentedTextButton}
+                onClick={() => setShareOpen(true)}
+              >
+                <Text>Share</Text>
+              </button>
+              <Tooltip
+                label={copying ? 'Copied!' : 'Copy link'}
+                trigger={
+                  <button
+                    type="button"
+                    aria-label="Copy link"
+                    className={styles.segmentedIconButton}
+                    onClick={() => onCopyClick(window.location.href)}
+                  >
+                    {copying ? (
+                      <span className={styles.copyLinkSuccess}>
+                        <Check size={14} />
+                      </span>
+                    ) : (
+                      <Link size={14} />
+                    )}
+                  </button>
+                }
+              />
+            </div>
 
-          {themesEnabled && selectedThemes.length !== 1 ? (
-            <Menu
-              width="content"
-              align="end"
-              trigger={<ButtonIcon label="Launch Preview" icon={<Play />} />}
-            >
-              <MenuGroup label="Choose preview theme">
-                {availableThemes.map((theme) => (
-                  <MenuItemThemedPreviewLink key={theme} theme={theme} />
-                ))}
-              </MenuGroup>
-            </Menu>
-          ) : (
-            <ButtonIconLink
-              label="Launch Preview"
-              icon={<Play />}
-              href={previewUrl}
-              target="_blank"
-            />
-          )}
+            {themesEnabled && selectedThemes.length !== 1 ? (
+              <Menu
+                width="content"
+                align="end"
+                trigger={<ButtonIcon label="Launch Preview" icon={<Play />} />}
+              >
+                <MenuGroup label="Choose preview theme">
+                  {availableThemes.map((theme) => (
+                    <MenuItemThemedPreviewLink key={theme} theme={theme} />
+                  ))}
+                </MenuGroup>
+              </Menu>
+            ) : (
+              <ButtonIconLink
+                label="Launch Preview"
+                icon={<Play />}
+                href={previewUrl}
+                target="_blank"
+              />
+            )}
+          </div>
 
           <Menu
             width="small"


### PR DESCRIPTION
Only hide share actions from header without code

The header actions in the top right are now available on page load.
This enables the selection of frames and/or themes before any code is added to the editor.

The share and preview actions are still hidden and revealed when code is entered into the editor.