### PR TITLE
Inspect: Add inspector to connect rendered element to code line

### DIFF
--- a/.changeset/salty-crabs-relax.md
+++ b/.changeset/salty-crabs-relax.md
@@ -1,0 +1,5 @@
+---
+'playroom': minor
+---
+
+Inspect: Add inspector to connect rendered element to code line

--- a/cypress/e2e/inspectElement.cy.ts
+++ b/cypress/e2e/inspectElement.cy.ts
@@ -98,6 +98,23 @@ describe('Inspect Element', () => {
         .and('have.css', 'height', '100px');
     });
 
+    it('highlights parent element when hovering content rendered via dangerouslySetInnerHTML', () => {
+      loadPlayroom(`
+        <Foo />
+        <div data-test-target style={{ height: 80 }} dangerouslySetInnerHTML={{ __html: '<span data-inner>Inner HTML</span>' }} />
+      `);
+
+      assertFirstFrameContains('Foo\nInner HTML');
+      toggleInspectMode({ source: 'button' });
+      assertInspectOverlayInFrame();
+
+      hoverTargetInFrame('[data-inner]');
+
+      getInspectHighlight()
+        .should('be.visible')
+        .and('have.css', 'height', '80px');
+    });
+
     it('shows the editor when panels were hidden', () => {
       loadPlayroom(`
         <Foo />

--- a/cypress/e2e/inspectElement.cy.ts
+++ b/cypress/e2e/inspectElement.cy.ts
@@ -1,0 +1,165 @@
+import {
+  assertFirstFrameContains,
+  assertInspectModeActive,
+  assertInspectModeInactive,
+  assertInspectOverlayInFrame,
+  cmdPlus,
+  toggleInspectMode,
+  getCodeEditor,
+  getInspectHighlight,
+  hoverTargetInFrame,
+  loadPlayroom,
+  simulateInspectMessage,
+  typeCode,
+} from '../support/utils';
+
+describe('Inspect Element', () => {
+  describe('Activation', () => {
+    it('activates via button click', () => {
+      loadPlayroom();
+      typeCode('<Foo />');
+
+      toggleInspectMode({ source: 'button' });
+      assertInspectModeActive();
+    });
+
+    it('activates via keyboard shortcut', () => {
+      loadPlayroom();
+      typeCode('<Foo />');
+
+      toggleInspectMode({ source: 'keyboard' });
+      assertInspectModeActive();
+    });
+
+    it('renders inspect overlay inside frames when activated', () => {
+      loadPlayroom();
+      typeCode('<Foo />');
+
+      assertFirstFrameContains('Foo');
+      toggleInspectMode({ source: 'button' });
+      assertInspectOverlayInFrame();
+    });
+  });
+
+  describe('Deactivation', () => {
+    it('deactivates via Escape key', () => {
+      loadPlayroom();
+      typeCode('<Foo />');
+
+      toggleInspectMode({ source: 'button' });
+      cy.get('body').type('{esc}');
+      assertInspectModeInactive();
+    });
+
+    it('deactivates via keyboard shortcut toggle', () => {
+      loadPlayroom();
+      typeCode('<Foo />');
+
+      toggleInspectMode({ source: 'keyboard' });
+      toggleInspectMode({ source: 'keyboard' });
+      assertInspectModeInactive();
+    });
+
+    it('deactivates when clicking outside iframes', () => {
+      loadPlayroom();
+      typeCode('<Foo />');
+
+      toggleInspectMode({ source: 'button' });
+      getCodeEditor().click();
+      assertInspectModeInactive();
+    });
+
+    it('deactivates when iframe sends exit message', () => {
+      loadPlayroom();
+      typeCode('<Foo />');
+
+      toggleInspectMode({ source: 'button' });
+      simulateInspectMessage('exit');
+      assertInspectModeInactive();
+    });
+  });
+
+  describe('Element Selection', () => {
+    it('positions overlay over hovered element', () => {
+      loadPlayroom(`
+        <Foo />
+        <Bar />
+        <div data-test-target style={{ border: '10px solid green', color: 'green', fontSize: 40, fontWeight: 700, height: 100 }}>Target Element</div>
+      `);
+
+      assertFirstFrameContains('Foo\nBar\nTarget Element');
+      toggleInspectMode({ source: 'button' });
+      assertInspectOverlayInFrame();
+
+      hoverTargetInFrame('[data-test-target]');
+
+      getInspectHighlight()
+        .should('be.visible')
+        .and('have.css', 'height', '100px');
+    });
+
+    it('shows the editor when panels were hidden', () => {
+      loadPlayroom(`
+        <Foo />
+        <Bar />
+      `);
+
+      getCodeEditor().should('be.visible');
+      cy.get('body').type(cmdPlus('\\'));
+      getCodeEditor().should('not.be.visible');
+
+      toggleInspectMode({ source: 'keyboard' });
+      simulateInspectMessage('select', 0);
+
+      getCodeEditor().should('be.visible');
+      assertInspectModeInactive();
+    });
+
+    it('positions cursor at the selected line', () => {
+      loadPlayroom(`
+        <Foo />
+        <Bar />
+        <Foo color="red" />
+      `);
+
+      toggleInspectMode({ source: 'button' });
+      simulateInspectMessage('select', 1);
+
+      getCodeEditor().should('be.visible');
+
+      cy.get('.CodeMirror').should(($cm) => {
+        const cursor = ($cm[0] as any).CodeMirror.getCursor();
+        expect(cursor.line).to.equal(1);
+        expect(cursor.ch).to.equal(0);
+      });
+    });
+  });
+
+  describe('Hover Highlighting', () => {
+    it('highlights the corresponding line in the editor', () => {
+      loadPlayroom(`
+        <Foo />
+        <Bar />
+        <Foo color="red" />
+      `);
+
+      toggleInspectMode({ source: 'button' });
+      simulateInspectMessage('hover', 1);
+      cy.get('.cm-inspect-highlight').should('exist');
+    });
+
+    it('removes highlight when hover line is null', () => {
+      loadPlayroom(`
+        <Foo />
+        <Bar />
+      `);
+
+      toggleInspectMode({ source: 'button' });
+      simulateInspectMessage('hover', 0);
+      cy.get('.cm-inspect-highlight').should('exist');
+
+      simulateInspectMessage('hover', null);
+      cy.get('.cm-inspect-highlight').should('not.exist');
+    });
+  });
+});

--- a/cypress/e2e/reactFiberContract.cy.ts
+++ b/cypress/e2e/reactFiberContract.cy.ts
@@ -1,0 +1,82 @@
+import {
+  assertFirstFrameContains,
+  getFirstFrameBody,
+  loadPlayroom,
+  typeCode,
+} from '../support/utils';
+
+describe('React Fiber Contract', () => {
+  beforeEach(() => {
+    loadPlayroom();
+    typeCode('<Foo /><div data-testid="fiber-test">hello</div>');
+    assertFirstFrameContains('Foo\nhello');
+  });
+
+  it('exposes __reactFiber$ on host elements rendered by custom components', () => {
+    getFirstFrameBody()
+      .contains('Foo')
+      .should(($el) => {
+        const fiberKey = Object.keys($el[0]).find((k) =>
+          k.startsWith('__reactFiber$')
+        );
+
+        expect(
+          fiberKey,
+          'Expected __reactFiber$ property on DOM element rendered by a custom component. ' +
+            "Playroom's Inspect Element feature depends on this React internal to walk the fiber tree. " +
+            'If this fails after a React upgrade, update getFiberKey() in src/components/Frame/InspectOverlay.tsx.'
+        ).to.not.equal(undefined);
+      });
+  });
+
+  it('exposes __reactFiber$ on standard host elements', () => {
+    getFirstFrameBody()
+      .find('[data-testid="fiber-test"]')
+      .should(($el) => {
+        const fiberKey = Object.keys($el[0]).find((k) =>
+          k.startsWith('__reactFiber$')
+        );
+
+        expect(
+          fiberKey,
+          'Expected __reactFiber$ property on a standard <div> element. ' +
+            "Playroom's Inspect Element feature depends on this React internal to walk the fiber tree. " +
+            'If this fails after a React upgrade, update getFiberKey() in src/components/Frame/InspectOverlay.tsx.'
+        ).to.not.equal(undefined);
+      });
+  });
+
+  it('fiber node has the shape Playroom depends on (memoizedProps, return)', () => {
+    getFirstFrameBody()
+      .find('[data-testid="fiber-test"]')
+      .should(($el) => {
+        const element: Record<string, unknown> = $el[0] as never;
+        const fiberKey = Object.keys(element).find((k) =>
+          k.startsWith('__reactFiber$')
+        );
+
+        expect(fiberKey, 'Expected __reactFiber$ key to exist').to.be.a(
+          'string'
+        );
+
+        const fiber = element[fiberKey as string] as Record<string, unknown>;
+
+        expect(fiber, 'Fiber node must be a non-null object').to.not.equal(
+          null
+        );
+        expect(fiber, 'Fiber node must be a non-null object').to.be.an(
+          'object'
+        );
+
+        expect(
+          fiber,
+          'Fiber node must have memoizedProps (used to read data-playroomline)'
+        ).to.have.property('memoizedProps');
+
+        expect(
+          fiber,
+          'Fiber node must have return (used to walk up the fiber tree)'
+        ).to.have.property('return');
+      });
+  });
+});

--- a/cypress/e2e/reactFiberContract.cy.ts
+++ b/cypress/e2e/reactFiberContract.cy.ts
@@ -8,13 +8,13 @@ import {
 describe('React Fiber Contract', () => {
   beforeEach(() => {
     loadPlayroom();
-    typeCode('<Foo /><div data-testid="fiber-test">hello</div>');
+    typeCode('<Foo /><div data-testid="fiber-test">hello');
     assertFirstFrameContains('Foo\nhello');
   });
 
   it('exposes __reactFiber$ on host elements rendered by custom components', () => {
     getFirstFrameBody()
-      .contains('Foo')
+      .find('[data-testid="foo-component"]')
       .should(($el) => {
         const fiberKey = Object.keys($el[0]).find((k) =>
           k.startsWith('__reactFiber$')

--- a/cypress/projects/basic/components.js
+++ b/cypress/projects/basic/components.js
@@ -14,7 +14,7 @@ const parent = {
 };
 
 export const Foo = withPropTypes(({ color = 'black', children }) => (
-  <div style={{ color }}>
+  <div data-testid="foo-component" style={{ color }}>
     Foo{children ? <div style={parent}>{children}</div> : null}
   </div>
 ));

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -566,7 +566,6 @@ export const assertFrameSettingsCount = (count: number) =>
   cy
     .findAllByRole('button', {
       name: frameSettingsButtonLabel,
-      hidden: true,
     })
     .should('have.length', count);
 
@@ -574,7 +573,6 @@ export const toggleFrameSettingsForFrameIndex = (index: number) =>
   cy
     .findAllByRole('button', {
       name: frameSettingsButtonLabel,
-      hidden: true,
     })
     .eq(index)
     .click();
@@ -590,3 +588,67 @@ export const assertFrameSetting = (settingName: string, value: string) => {
 export const selectFrameSettingForFrameIndex = (settingName: string) => {
   cy.findByRole('menuitemcheckbox', { name: settingName }).click();
 };
+
+export const getInspectButton = () =>
+  cy.findAllByRole('button', { name: 'Inspect element' }).first();
+
+export const toggleInspectMode = (options: {
+  source: 'button' | 'keyboard';
+}) => {
+  switch (options.source) {
+    case 'button': {
+      getInspectButton().click();
+      break;
+    }
+    case 'keyboard': {
+      cy.get('body').type(cmdPlus('shift+c'));
+      break;
+    }
+    default: {
+      throw new Error('No source provided');
+    }
+  }
+};
+
+export const assertInspectModeActive = () =>
+  getInspectButton().should('have.attr', 'aria-pressed', 'true');
+
+export const assertInspectModeInactive = () =>
+  getInspectButton().should('have.attr', 'aria-pressed', 'false');
+
+export const simulateInspectMessage = (
+  type: 'hover' | 'select' | 'exit',
+  line?: number | null
+) =>
+  cy.window().then((win) => {
+    win.postMessage(
+      { source: 'Playroom Inspect', type, ...(type !== 'exit' && { line }) },
+      '*'
+    );
+  });
+
+export const assertInspectOverlayInFrame = () =>
+  getFrames()
+    .first()
+    .its('0.contentDocument.body')
+    .find('[data-testid="inspect-overlay"]')
+    .should('exist');
+
+export const getFirstFrameBody = () =>
+  getFrames().first().its('0.contentDocument.body');
+
+export const hoverTargetInFrame = (selector: string) =>
+  getFirstFrameBody()
+    .find(selector)
+    .then(($target) => {
+      const rect = $target[0].getBoundingClientRect();
+      const clientX = rect.left + rect.width / 2;
+      const clientY = rect.top + rect.height / 2;
+
+      cy.wrap($target[0].ownerDocument.body)
+        .find('[data-testid="inspect-overlay"]')
+        .trigger('mousemove', { clientX, clientY });
+    });
+
+export const getInspectHighlight = () =>
+  getFirstFrameBody().find('[data-testid="inspect-overlay"]').prev(); // Get the highlight element

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -39,7 +39,7 @@ const clearCode = () => {
   typeCode('{backspace}');
 };
 
-const getFirstFrameBody = () =>
+export const getFirstFrameBody = () =>
   getFrames().first().its('0.contentDocument.body');
 
 export const typeCode = (code: string, delay?: number) =>

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -39,6 +39,9 @@ const clearCode = () => {
   typeCode('{backspace}');
 };
 
+const getFirstFrameBody = () =>
+  getFrames().first().its('0.contentDocument.body');
+
 export const typeCode = (code: string, delay?: number) =>
   getCodeEditor().focused().type(code, { delay });
 
@@ -243,12 +246,9 @@ export const assertSnippetCount = (count: number) =>
   getSnippets().should('have.length', count);
 
 export const assertFirstFrameContains = (text: string) =>
-  getFrames()
-    .first()
-    .its('0.contentDocument.body')
-    .should((frameBody) => {
-      expect(frameBody.innerText).to.eq(text);
-    });
+  getFirstFrameBody().should((frameBody) => {
+    expect(frameBody.innerText).to.eq(text);
+  });
 
 export const assertFirstFrameError = (error: string) =>
   getFrameErrors()
@@ -628,14 +628,7 @@ export const simulateInspectMessage = (
   });
 
 export const assertInspectOverlayInFrame = () =>
-  getFrames()
-    .first()
-    .its('0.contentDocument.body')
-    .find('[data-testid="inspect-overlay"]')
-    .should('exist');
-
-export const getFirstFrameBody = () =>
-  getFrames().first().its('0.contentDocument.body');
+  getFirstFrameBody().find('[data-testid="inspect-overlay"]').should('exist');
 
 export const hoverTargetInFrame = (selector: string) =>
   getFirstFrameBody()

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,7 @@ export default defineConfig([
   ...eslintConfigSeek,
   {
     rules: {
+      curly: 'error',
       'import-x/order': [
         'error',
         {

--- a/src/components/ButtonIcon/ButtonIcon.css.ts
+++ b/src/components/ButtonIcon/ButtonIcon.css.ts
@@ -133,7 +133,8 @@ export const variant = styleVariants({
         [comma(
           `${button}:not([aria-disabled="true"]):hover > &`,
           `${button}:not([aria-disabled="true"]):focus-visible > &`,
-          `${button}:not([aria-disabled="true"])[data-popup-open] > &`
+          `${button}:not([aria-disabled="true"])[data-popup-open] > &`,
+          `${button}:not([aria-disabled="true"])[data-active] > &`
         )]: {
           backgroundColor: backgroundStandardHover,
         },
@@ -148,7 +149,8 @@ export const variant = styleVariants({
         [comma(
           `${button}:not([aria-disabled="true"]):hover > &`,
           `${button}:not([aria-disabled="true"]):focus-visible > &`,
-          `${button}:not([aria-disabled="true"])[data-popup-open] > &`
+          `${button}:not([aria-disabled="true"])[data-popup-open] > &`,
+          `${button}:not([aria-disabled="true"])[data-active] > &`
         )]: {
           backgroundColor: backgroundSolidHover,
         },
@@ -162,7 +164,8 @@ export const variant = styleVariants({
         [comma(
           `${button}:not([aria-disabled="true"]):hover > &`,
           `${button}:not([aria-disabled="true"]):focus-visible > &`,
-          `${button}:not([aria-disabled="true"])[data-popup-open] > &`
+          `${button}:not([aria-disabled="true"])[data-popup-open] > &`,
+          `${button}:not([aria-disabled="true"])[data-active] > &`
         )]: {
           color: foregroundTransparentHover,
           backgroundColor: backgroundTransparentHover,

--- a/src/components/ButtonIcon/ButtonIcon.tsx
+++ b/src/components/ButtonIcon/ButtonIcon.tsx
@@ -2,6 +2,12 @@ import type { Tooltip as BaseUITooltip } from '@base-ui/react/tooltip';
 import clsx from 'clsx';
 import { type AllHTMLAttributes, forwardRef, type ComponentProps } from 'react';
 
+import { Inline } from '../Inline/Inline';
+import {
+  KeyboardShortcut,
+  type KeyCombination,
+} from '../KeyboardShortcut/KeyboardShortcut';
+import { Secondary } from '../Secondary/Secondary';
 import { Tooltip, type TooltipTrigger } from '../Tooltip/Tooltip';
 
 import * as styles from './ButtonIcon.css';
@@ -11,8 +17,10 @@ type ButtonIconBaseProps = {
   label: string;
   size?: keyof typeof styles.size;
   tone?: keyof typeof styles.tone;
+  shortcut?: KeyCombination;
   variant?: keyof typeof styles.variant;
   bleed?: boolean;
+  active?: boolean;
   disabledReason?: string;
 };
 export type ButtonIconProps = TooltipTrigger & ButtonIconBaseProps;
@@ -25,6 +33,8 @@ export const ButtonIcon = forwardRef<HTMLButtonElement, ButtonIconProps>(
       tone = 'neutral',
       variant = 'standard',
       bleed,
+      shortcut,
+      active,
       disabled,
       disabledReason,
       type = 'button',
@@ -33,7 +43,20 @@ export const ButtonIcon = forwardRef<HTMLButtonElement, ButtonIconProps>(
     ref
   ) => (
     <Tooltip
-      label={disabled && disabledReason ? disabledReason : label}
+      label={
+        disabled && disabledReason ? (
+          disabledReason
+        ) : (
+          <Inline space="xxsmall" nowrap>
+            <span>{label}</span>
+            {shortcut ? (
+              <Secondary>
+                <KeyboardShortcut shortcut={shortcut} hideOnMobile={false} />
+              </Secondary>
+            ) : null}
+          </Inline>
+        )
+      }
       sideOffset={size === 'small' ? 4 : undefined}
       trigger={
         <button
@@ -41,7 +64,9 @@ export const ButtonIcon = forwardRef<HTMLButtonElement, ButtonIconProps>(
           type={type}
           ref={ref}
           aria-disabled={disabled}
+          aria-pressed={active}
           aria-label={label}
+          data-active={active || undefined}
           className={clsx({
             [styles.button]: true,
             [styles.tone[tone]]: true,

--- a/src/components/CodeEditor/CodeEditor.css.ts
+++ b/src/components/CodeEditor/CodeEditor.css.ts
@@ -332,3 +332,7 @@ globalStyle('.CodeMirror-dialog button:focus-visible', {
 globalStyle('.CodeMirror-dialog button:hover', {
   background: colorPaletteVars.background.selection,
 });
+
+globalStyle('.cm-inspect-highlight', {
+  backgroundColor: colorPaletteVars.background.inspectOverlay,
+});

--- a/src/components/CodeEditor/CodeEditor.css.ts
+++ b/src/components/CodeEditor/CodeEditor.css.ts
@@ -1,4 +1,4 @@
-import { style, globalStyle } from '@vanilla-extract/css';
+import { style, globalStyle, keyframes } from '@vanilla-extract/css';
 
 import { colorPaletteVars, sprinkles } from '../../css/sprinkles.css';
 import { fontSizeDefinitions, vars } from '../../css/vars.css';
@@ -334,5 +334,14 @@ globalStyle('.CodeMirror-dialog button:hover', {
 });
 
 globalStyle('.cm-inspect-highlight', {
-  backgroundColor: colorPaletteVars.background.inspectOverlay,
+  backgroundColor: `${colorPaletteVars.background.inspectOverlay} !important`,
+});
+
+const inspectFadeOut = keyframes({
+  from: { backgroundColor: colorPaletteVars.background.inspectOverlay },
+  to: { backgroundColor: 'transparent' },
+});
+
+globalStyle('.cm-inspect-highlight-fade', {
+  animation: `${inspectFadeOut} 1s ease forwards`,
 });

--- a/src/components/CodeEditor/CodeEditor.css.ts
+++ b/src/components/CodeEditor/CodeEditor.css.ts
@@ -334,11 +334,11 @@ globalStyle('.CodeMirror-dialog button:hover', {
 });
 
 globalStyle('.cm-inspect-highlight', {
-  backgroundColor: `${colorPaletteVars.background.inspectOverlay} !important`,
+  backgroundColor: `${colorPaletteVars.background.textSelection} !important`,
 });
 
 const inspectFadeOut = keyframes({
-  from: { backgroundColor: colorPaletteVars.background.inspectOverlay },
+  from: { backgroundColor: colorPaletteVars.background.textSelection },
   to: { backgroundColor: 'transparent' },
 });
 

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -19,7 +19,7 @@ type FrameComponentProps = {
   children?: ReactNode;
 };
 
-interface FrameProps extends Pick<RenderCodeProps, 'code'> {
+interface FrameProps extends Pick<RenderCodeProps, 'code' | 'inspectMode'> {
   themeName: FrameComponentProps['themeName'];
   theme: FrameComponentProps['theme'];
   frameSettings?: FrameComponentProps['frameSettings'];
@@ -27,6 +27,7 @@ interface FrameProps extends Pick<RenderCodeProps, 'code'> {
 }
 export default function Frame({
   code,
+  inspectMode,
   themeName,
   theme,
   frameSettings,
@@ -63,7 +64,11 @@ export default function Frame({
           theme={theme}
           frameSettings={frameSettings}
         >
-          <RenderCode code={code} onError={setError} />
+          <RenderCode
+            code={code}
+            inspectMode={inspectMode}
+            onError={setError}
+          />
         </FrameComponent>
       </ErrorBoundary>
       <ErrorComponent message={error} delayVisibility={delay.current} />

--- a/src/components/Frame/InspectOverlay.css.ts
+++ b/src/components/Frame/InspectOverlay.css.ts
@@ -17,7 +17,6 @@ export const highlight = style([
   sprinkles({
     position: 'fixed',
     pointerEvents: 'none',
-    borderRadius: 'small',
   }),
   {
     zIndex: 99999,

--- a/src/components/Frame/InspectOverlay.css.ts
+++ b/src/components/Frame/InspectOverlay.css.ts
@@ -20,6 +20,7 @@ export const highlight = style([
     borderRadius: 'small',
   }),
   {
+    zIndex: 99999,
     background: colorPaletteVars.background.inspectOverlay,
     transition: 'all 50ms ease',
   },

--- a/src/components/Frame/InspectOverlay.css.ts
+++ b/src/components/Frame/InspectOverlay.css.ts
@@ -1,0 +1,26 @@
+import { style } from '@vanilla-extract/css';
+
+import { colorPaletteVars, sprinkles } from '../../css/sprinkles.css';
+
+export const overlay = style([
+  sprinkles({
+    position: 'fixed',
+    inset: 0,
+  }),
+  {
+    zIndex: 99999,
+    cursor: 'crosshair',
+  },
+]);
+
+export const highlight = style([
+  sprinkles({
+    position: 'fixed',
+    pointerEvents: 'none',
+    borderRadius: 'small',
+  }),
+  {
+    background: colorPaletteVars.background.inspectOverlay,
+    transition: 'all 50ms ease',
+  },
+]);

--- a/src/components/Frame/InspectOverlay.css.ts
+++ b/src/components/Frame/InspectOverlay.css.ts
@@ -22,5 +22,6 @@ export const highlight = style([
     zIndex: 99999,
     background: colorPaletteVars.background.inspectOverlay,
     transition: 'all 50ms ease',
+    transitionDelay: '50ms',
   },
 ]);

--- a/src/components/Frame/InspectOverlay.tsx
+++ b/src/components/Frame/InspectOverlay.tsx
@@ -241,6 +241,17 @@ export const InspectOverlay = () => {
     }
   }, []);
 
+  const handleMouseLeave = useCallback(() => {
+    setHighlightRect(null);
+    if (lastLineRef.current !== null) {
+      lastLineRef.current = null;
+      window.parent.postMessage(
+        { source: PlayroomInspectSource, type: 'hover', line: null },
+        '*'
+      );
+    }
+  }, []);
+
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
       e.preventDefault();
@@ -251,7 +262,9 @@ export const InspectOverlay = () => {
     }
   }, []);
 
-  if (!enabled) return null;
+  if (!enabled) {
+    return null;
+  }
 
   return (
     <>
@@ -269,6 +282,7 @@ export const InspectOverlay = () => {
       <div
         className={styles.overlay}
         onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         tabIndex={0}

--- a/src/components/Frame/InspectOverlay.tsx
+++ b/src/components/Frame/InspectOverlay.tsx
@@ -4,6 +4,8 @@ import { PlayroomInspectSource } from './frameMessenger';
 
 import * as styles from './InspectOverlay.css';
 
+const INSPECT_LINE_KEY = 'data-playroom-line';
+
 interface HighlightRect {
   top: number;
   left: number;
@@ -21,30 +23,103 @@ function getVisibleRect(el: Element): HighlightRect | null {
       height: rect.height,
     };
   }
-  // For display:contents elements, compute bounding box from children
-  const children = el.children;
-  if (children.length === 0) {
-    return null;
+  return null;
+}
+
+function getPropsKey(el: Element): string | undefined {
+  return Object.keys(el).find((k) => k.startsWith('__reactProps$'));
+}
+
+function getFiberKey(el: Element): string | undefined {
+  return Object.keys(el).find((k) => k.startsWith('__reactFiber$'));
+}
+
+interface InspectResult {
+  line: number;
+  element: Element;
+}
+
+function findInspectTarget(el: Element): InspectResult | null {
+  // Check __reactProps$ on the hovered DOM element
+  const propsKey = getPropsKey(el);
+  if (propsKey) {
+    const props = (el as any)[propsKey];
+    if (props?.[INSPECT_LINE_KEY] != null) {
+      return { line: Number(props[INSPECT_LINE_KEY]), element: el };
+    }
   }
 
-  let top = Infinity;
-  let left = Infinity;
-  let bottom = -Infinity;
-  let right = -Infinity;
-
-  for (const child of Array.from(children)) {
-    const childRect = child.getBoundingClientRect();
-    if (childRect.width === 0 && childRect.height === 0) continue;
-    top = Math.min(top, childRect.top);
-    left = Math.min(left, childRect.left);
-    bottom = Math.max(bottom, childRect.bottom);
-    right = Math.max(right, childRect.right);
+  // Walk up DOM tree
+  let child: Element = el;
+  let current: Element | null = el.parentElement;
+  while (current) {
+    const pk = getPropsKey(current);
+    if (pk) {
+      const props = (current as any)[pk];
+      // Check children for component boundaries matching our hovered subtree
+      const childLine = findLineForChild(props?.children, child, current);
+      if (childLine != null) {
+        return { line: childLine, element: child };
+      }
+      if (props?.[INSPECT_LINE_KEY] != null) {
+        return { line: Number(props[INSPECT_LINE_KEY]), element: current };
+      }
+    }
+    child = current;
+    current = current.parentElement;
   }
 
-  if (top === Infinity) {
-    return null;
+  return null;
+}
+
+function findLineForChild(
+  children: any,
+  child: Element,
+  parent: Element
+): number | null {
+  if (!children) return null;
+
+  const flatChildren = flattenChildren(children);
+  const fiberKey = getFiberKey(child);
+  if (!fiberKey) return null;
+
+  let fiber = (child as any)[fiberKey];
+  while (fiber) {
+    if (fiber.stateNode === parent) break;
+
+    if (typeof fiber.type === 'function' || typeof fiber.type === 'object') {
+      for (const reactChild of flatChildren) {
+        if (!reactChild || typeof reactChild !== 'object') continue;
+        if (
+          reactChild.type === fiber.type &&
+          reactChild.props?.[INSPECT_LINE_KEY] != null
+        ) {
+          return Number(reactChild.props[INSPECT_LINE_KEY]);
+        }
+      }
+    }
+    fiber = fiber.return;
   }
-  return { top, left, width: right - left, height: bottom - top };
+
+  return null;
+}
+
+function flattenChildren(children: any): any[] {
+  if (!children) return [];
+  const arr = Array.isArray(children) ? children : [children];
+  const result: any[] = [];
+  for (const child of arr) {
+    if (!child || typeof child !== 'object') continue;
+    if (
+      child.type === Symbol.for('react.fragment') ||
+      child.type === Symbol.for('react.transitional.element')
+    ) {
+      result.push(...flattenChildren(child.props?.children));
+    } else {
+      result.push(child);
+    }
+  }
+  return result;
 }
 
 export const InspectOverlay = () => {
@@ -122,8 +197,8 @@ export const InspectOverlay = () => {
       return;
     }
 
-    const annotated = el.closest('[data-playroom-line]');
-    if (!annotated) {
+    const target = findInspectTarget(el);
+    if (!target) {
       setHighlightRect(null);
       if (lastLineRef.current !== null) {
         lastLineRef.current = null;
@@ -135,14 +210,12 @@ export const InspectOverlay = () => {
       return;
     }
 
-    const visibleRect = getVisibleRect(annotated);
-    setHighlightRect(visibleRect);
+    setHighlightRect(getVisibleRect(target.element));
 
-    const line = Number(annotated.getAttribute('data-playroom-line'));
-    if (line !== lastLineRef.current) {
-      lastLineRef.current = line;
+    if (target.line !== lastLineRef.current) {
+      lastLineRef.current = target.line;
       window.parent.postMessage(
-        { source: PlayroomInspectSource, type: 'hover', line },
+        { source: PlayroomInspectSource, type: 'hover', line: target.line },
         '*'
       );
     }
@@ -158,11 +231,10 @@ export const InspectOverlay = () => {
     overlay.style.pointerEvents = '';
 
     if (el) {
-      const annotated = el.closest('[data-playroom-line]');
-      if (annotated) {
-        const line = Number(annotated.getAttribute('data-playroom-line'));
+      const target = findInspectTarget(el);
+      if (target) {
         window.parent.postMessage(
-          { source: PlayroomInspectSource, type: 'select', line },
+          { source: PlayroomInspectSource, type: 'select', line: target.line },
           '*'
         );
       }

--- a/src/components/Frame/InspectOverlay.tsx
+++ b/src/components/Frame/InspectOverlay.tsx
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { PlayroomInspectSource } from './frameMessenger';
+
+import * as styles from './InspectOverlay.css';
+
+interface HighlightRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+function getVisibleRect(el: Element): HighlightRect | null {
+  const rect = el.getBoundingClientRect();
+  if (rect.width > 0 && rect.height > 0) {
+    return {
+      top: rect.top,
+      left: rect.left,
+      width: rect.width,
+      height: rect.height,
+    };
+  }
+  // For display:contents elements, compute bounding box from children
+  const children = el.children;
+  if (children.length === 0) {
+    return null;
+  }
+
+  let top = Infinity;
+  let left = Infinity;
+  let bottom = -Infinity;
+  let right = -Infinity;
+
+  for (const child of Array.from(children)) {
+    const childRect = child.getBoundingClientRect();
+    if (childRect.width === 0 && childRect.height === 0) continue;
+    top = Math.min(top, childRect.top);
+    left = Math.min(left, childRect.left);
+    bottom = Math.max(bottom, childRect.bottom);
+    right = Math.max(right, childRect.right);
+  }
+
+  if (top === Infinity) {
+    return null;
+  }
+  return { top, left, width: right - left, height: bottom - top };
+}
+
+export const InspectOverlay = () => {
+  const [enabled, setEnabled] = useState(false);
+  const [highlightRect, setHighlightRect] = useState<HighlightRect | null>(
+    null
+  );
+  const lastLineRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data?.source !== PlayroomInspectSource) {
+        return;
+      }
+
+      if (event.data.action === 'enable') {
+        setEnabled(true);
+      } else if (event.data.action === 'disable') {
+        setEnabled(false);
+        setHighlightRect(null);
+        lastLineRef.current = null;
+      }
+    };
+
+    const handleScroll = () => {
+      setHighlightRect(null);
+    };
+
+    window.addEventListener('message', handleMessage);
+    window.addEventListener('scroll', handleScroll, true);
+    return () => {
+      window.removeEventListener('message', handleMessage);
+      window.removeEventListener('scroll', handleScroll, true);
+    };
+  }, []);
+
+  // Fallback: detect when annotated elements appear in the DOM
+  useEffect(() => {
+    if (enabled) {
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      if (document.querySelector('[data-playroom-line]')) {
+        setEnabled(true);
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-playroom-line'],
+    });
+
+    return () => observer.disconnect();
+  }, [enabled]);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    const overlay = e.currentTarget as HTMLElement;
+    overlay.style.pointerEvents = 'none';
+    const el = document.elementFromPoint(e.clientX, e.clientY);
+    overlay.style.pointerEvents = '';
+
+    if (!el) {
+      setHighlightRect(null);
+      if (lastLineRef.current !== null) {
+        lastLineRef.current = null;
+        window.parent.postMessage(
+          { source: PlayroomInspectSource, type: 'hover', line: null },
+          '*'
+        );
+      }
+      return;
+    }
+
+    const annotated = el.closest('[data-playroom-line]');
+    if (!annotated) {
+      setHighlightRect(null);
+      if (lastLineRef.current !== null) {
+        lastLineRef.current = null;
+        window.parent.postMessage(
+          { source: PlayroomInspectSource, type: 'hover', line: null },
+          '*'
+        );
+      }
+      return;
+    }
+
+    const visibleRect = getVisibleRect(annotated);
+    setHighlightRect(visibleRect);
+
+    const line = Number(annotated.getAttribute('data-playroom-line'));
+    if (line !== lastLineRef.current) {
+      lastLineRef.current = line;
+      window.parent.postMessage(
+        { source: PlayroomInspectSource, type: 'hover', line },
+        '*'
+      );
+    }
+  }, []);
+
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const overlay = e.currentTarget as HTMLElement;
+    overlay.style.pointerEvents = 'none';
+    const el = document.elementFromPoint(e.clientX, e.clientY);
+    overlay.style.pointerEvents = '';
+
+    if (el) {
+      const annotated = el.closest('[data-playroom-line]');
+      if (annotated) {
+        const line = Number(annotated.getAttribute('data-playroom-line'));
+        window.parent.postMessage(
+          { source: PlayroomInspectSource, type: 'select', line },
+          '*'
+        );
+      }
+    }
+  }, []);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      window.parent.postMessage(
+        { source: PlayroomInspectSource, type: 'exit' },
+        '*'
+      );
+    }
+  }, []);
+
+  if (!enabled) return null;
+
+  return (
+    <>
+      {highlightRect && (
+        <div
+          className={styles.highlight}
+          style={{
+            top: highlightRect.top,
+            left: highlightRect.left,
+            width: highlightRect.width,
+            height: highlightRect.height,
+          }}
+        />
+      )}
+      <div
+        className={styles.overlay}
+        onMouseMove={handleMouseMove}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        tabIndex={0}
+        autoFocus
+      />
+    </>
+  );
+};

--- a/src/components/Frame/InspectOverlay.tsx
+++ b/src/components/Frame/InspectOverlay.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { PlayroomInspectSource } from './frameMessenger';
+import { InspectMessageReceiver, inspectMessageSender } from './frameMessenger';
 
 import * as styles from './InspectOverlay.css';
 
@@ -140,31 +140,10 @@ export const InspectOverlay = () => {
   );
   const lastLineRef = useRef<number | null>(null);
 
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      if (event.data?.source !== PlayroomInspectSource) {
-        return;
-      }
-
-      if (event.data.action === 'enable') {
-        setEnabled(true);
-      } else if (event.data.action === 'disable') {
-        setEnabled(false);
-        setHighlightRect(null);
-        lastLineRef.current = null;
-      }
-    };
-
-    const handleScroll = () => {
-      setHighlightRect(null);
-    };
-
-    window.addEventListener('message', handleMessage);
-    window.addEventListener('scroll', handleScroll, true);
-    return () => {
-      window.removeEventListener('message', handleMessage);
-      window.removeEventListener('scroll', handleScroll, true);
-    };
+  const handleDisable = useCallback(() => {
+    setEnabled(false);
+    setHighlightRect(null);
+    lastLineRef.current = null;
   }, []);
 
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
@@ -177,10 +156,7 @@ export const InspectOverlay = () => {
       setHighlightRect(null);
       if (lastLineRef.current !== null) {
         lastLineRef.current = null;
-        window.parent.postMessage(
-          { source: PlayroomInspectSource, type: 'hover', line: null },
-          '*'
-        );
+        inspectMessageSender(window.parent, { type: 'hover', line: null });
       }
       return;
     }
@@ -190,10 +166,7 @@ export const InspectOverlay = () => {
       setHighlightRect(null);
       if (lastLineRef.current !== null) {
         lastLineRef.current = null;
-        window.parent.postMessage(
-          { source: PlayroomInspectSource, type: 'hover', line: null },
-          '*'
-        );
+        inspectMessageSender(window.parent, { type: 'hover', line: null });
       }
       return;
     }
@@ -202,10 +175,10 @@ export const InspectOverlay = () => {
 
     if (target.line !== lastLineRef.current) {
       lastLineRef.current = target.line;
-      window.parent.postMessage(
-        { source: PlayroomInspectSource, type: 'hover', line: target.line },
-        '*'
-      );
+      inspectMessageSender(window.parent, {
+        type: 'hover',
+        line: target.line,
+      });
     }
   }, []);
 
@@ -221,10 +194,10 @@ export const InspectOverlay = () => {
     if (el) {
       const target = findInspectTarget(el);
       if (target) {
-        window.parent.postMessage(
-          { source: PlayroomInspectSource, type: 'select', line: target.line },
-          '*'
-        );
+        inspectMessageSender(window.parent, {
+          type: 'select',
+          line: target.line,
+        });
       }
     }
   }, []);
@@ -233,50 +206,59 @@ export const InspectOverlay = () => {
     setHighlightRect(null);
     if (lastLineRef.current !== null) {
       lastLineRef.current = null;
-      window.parent.postMessage(
-        { source: PlayroomInspectSource, type: 'hover', line: null },
-        '*'
-      );
+      inspectMessageSender(window.parent, { type: 'hover', line: null });
     }
   }, []);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
       e.preventDefault();
-      window.parent.postMessage(
-        { source: PlayroomInspectSource, type: 'exit' },
-        '*'
-      );
+      inspectMessageSender(window.parent, { type: 'exit' });
     }
   }, []);
 
-  if (!enabled) {
-    return null;
-  }
+  const handleScroll = useCallback(() => {
+    setHighlightRect(null);
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll, true);
+    return () => {
+      window.removeEventListener('scroll', handleScroll, true);
+    };
+  }, [handleScroll]);
 
   return (
     <>
-      {highlightRect && (
-        <div
-          className={styles.highlight}
-          style={{
-            top: highlightRect.top,
-            left: highlightRect.left,
-            width: highlightRect.width,
-            height: highlightRect.height,
-          }}
-        />
-      )}
-      <div
-        className={styles.overlay}
-        data-testid="inspect-overlay"
-        onMouseMove={handleMouseMove}
-        onMouseLeave={handleMouseLeave}
-        onClick={handleClick}
-        onKeyDown={handleKeyDown}
-        tabIndex={0}
-        autoFocus
+      <InspectMessageReceiver
+        onEnable={() => setEnabled(true)}
+        onDisable={enabled ? handleDisable : undefined}
       />
+      {enabled && (
+        <>
+          {highlightRect && (
+            <div
+              className={styles.highlight}
+              style={{
+                top: highlightRect.top,
+                left: highlightRect.left,
+                width: highlightRect.width,
+                height: highlightRect.height,
+              }}
+            />
+          )}
+          <div
+            className={styles.overlay}
+            data-testid="inspect-overlay"
+            onMouseMove={handleMouseMove}
+            onMouseLeave={handleMouseLeave}
+            onClick={handleClick}
+            onKeyDown={handleKeyDown}
+            tabIndex={0}
+            autoFocus
+          />
+        </>
+      )}
     </>
   );
 };

--- a/src/components/Frame/InspectOverlay.tsx
+++ b/src/components/Frame/InspectOverlay.tsx
@@ -4,8 +4,6 @@ import { PlayroomInspectSource } from './frameMessenger';
 
 import * as styles from './InspectOverlay.css';
 
-const INSPECT_LINE_KEY = 'data-playroom-line';
-
 interface HighlightRect {
   top: number;
   left: number;
@@ -26,12 +24,35 @@ function getVisibleRect(el: Element): HighlightRect | null {
   return null;
 }
 
-function getPropsKey(el: Element): string | undefined {
-  return Object.keys(el).find((k) => k.startsWith('__reactProps$'));
-}
-
 function getFiberKey(el: Element): string | undefined {
   return Object.keys(el).find((k) => k.startsWith('__reactFiber$'));
+}
+
+function getLineFromFiber(fiber: any): number | null {
+  const props = fiber.memoizedProps;
+  const line =
+    typeof fiber.type === 'string'
+      ? props?.['data-playroomline']
+      : props?.__playroomLine;
+  return typeof line === 'number' ? line : null;
+}
+
+function findHostElement(fiber: any): Element | null {
+  if (fiber.stateNode instanceof Element) {
+    return fiber.stateNode;
+  }
+  let current = fiber.child;
+  while (current) {
+    if (current.stateNode instanceof Element) {
+      return current.stateNode;
+    }
+    const found = findHostElement(current);
+    if (found) {
+      return found;
+    }
+    current = current.sibling;
+  }
+  return null;
 }
 
 interface InspectResult {
@@ -39,87 +60,77 @@ interface InspectResult {
   element: Element;
 }
 
-function findInspectTarget(el: Element): InspectResult | null {
-  // Check __reactProps$ on the hovered DOM element
-  const propsKey = getPropsKey(el);
-  if (propsKey) {
-    const props = (el as any)[propsKey];
-    if (props?.[INSPECT_LINE_KEY] != null) {
-      return { line: Number(props[INSPECT_LINE_KEY]), element: el };
-    }
-  }
-
-  // Walk up DOM tree
-  let child: Element = el;
-  let current: Element | null = el.parentElement;
-  while (current) {
-    const pk = getPropsKey(current);
-    if (pk) {
-      const props = (current as any)[pk];
-      // Check children for component boundaries matching our hovered subtree
-      const childLine = findLineForChild(props?.children, child, current);
-      if (childLine != null) {
-        return { line: childLine, element: child };
-      }
-      if (props?.[INSPECT_LINE_KEY] != null) {
-        return { line: Number(props[INSPECT_LINE_KEY]), element: current };
-      }
-    }
-    child = current;
-    current = current.parentElement;
-  }
-
-  return null;
+interface ElementMatch {
+  type: any;
+  line: number;
 }
 
-function findLineForChild(
-  children: any,
-  child: Element,
-  parent: Element
-): number | null {
-  if (!children) return null;
+function findDeepestElementMatch(
+  element: any,
+  fiberTypes: Set<any>
+): ElementMatch | null {
+  if (!element || typeof element !== 'object') {
+    return null;
+  }
 
-  const flatChildren = flattenChildren(children);
-  const fiberKey = getFiberKey(child);
-  if (!fiberKey) return null;
+  let best: ElementMatch | null = null;
 
-  let fiber = (child as any)[fiberKey];
-  while (fiber) {
-    if (fiber.stateNode === parent) break;
+  if (element.props?.__playroomLine != null && fiberTypes.has(element.type)) {
+    best = { type: element.type, line: element.props.__playroomLine };
+  }
 
-    if (typeof fiber.type === 'function' || typeof fiber.type === 'object') {
-      for (const reactChild of flatChildren) {
-        if (!reactChild || typeof reactChild !== 'object') continue;
-        if (
-          reactChild.type === fiber.type &&
-          reactChild.props?.[INSPECT_LINE_KEY] != null
-        ) {
-          return Number(reactChild.props[INSPECT_LINE_KEY]);
-        }
+  const children = element.props?.children;
+  if (children) {
+    const childArr = Array.isArray(children) ? children : [children];
+    for (const child of childArr) {
+      const deeper = findDeepestElementMatch(child, fiberTypes);
+      if (deeper) {
+        best = deeper;
       }
     }
+  }
+
+  return best;
+}
+
+function findInspectTarget(el: Element): InspectResult | null {
+  const fiberKey = getFiberKey(el);
+  if (!fiberKey) {
+    return null;
+  }
+
+  const fiberPath: any[] = [];
+  let fiber = (el as any)[fiberKey];
+
+  while (fiber) {
+    fiberPath.push(fiber);
+
+    const line = getLineFromFiber(fiber);
+    if (line !== null) {
+      const fiberTypes = new Set(fiberPath.map((f) => f.type));
+      const childrenElement = fiber.memoizedProps?.children;
+      const deeperMatch = findDeepestElementMatch(childrenElement, fiberTypes);
+
+      if (deeperMatch) {
+        const targetFiber = fiberPath.find((f) => f.type === deeperMatch.type);
+        if (targetFiber) {
+          const hostEl = findHostElement(targetFiber);
+          if (hostEl) {
+            return { line: deeperMatch.line, element: hostEl };
+          }
+        }
+      }
+
+      const hostEl = findHostElement(fiber);
+      if (hostEl) {
+        return { line, element: hostEl };
+      }
+    }
+
     fiber = fiber.return;
   }
 
   return null;
-}
-
-function flattenChildren(children: any): any[] {
-  if (!children) return [];
-  const arr = Array.isArray(children) ? children : [children];
-  const result: any[] = [];
-  for (const child of arr) {
-    if (!child || typeof child !== 'object') continue;
-    if (
-      child.type === Symbol.for('react.fragment') ||
-      child.type === Symbol.for('react.transitional.element')
-    ) {
-      result.push(...flattenChildren(child.props?.children));
-    } else {
-      result.push(child);
-    }
-  }
-  return result;
 }
 
 export const InspectOverlay = () => {
@@ -155,29 +166,6 @@ export const InspectOverlay = () => {
       window.removeEventListener('scroll', handleScroll, true);
     };
   }, []);
-
-  // Fallback: detect when annotated elements appear in the DOM
-  useEffect(() => {
-    if (enabled) {
-      return;
-    }
-
-    const observer = new MutationObserver(() => {
-      if (document.querySelector('[data-playroom-line]')) {
-        setEnabled(true);
-        observer.disconnect();
-      }
-    });
-
-    observer.observe(document.body, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      attributeFilter: ['data-playroom-line'],
-    });
-
-    return () => observer.disconnect();
-  }, [enabled]);
 
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
     const overlay = e.currentTarget as HTMLElement;

--- a/src/components/Frame/InspectOverlay.tsx
+++ b/src/components/Frame/InspectOverlay.tsx
@@ -30,11 +30,14 @@ function getFiberKey(el: Element): string | undefined {
 
 function getLineFromFiber(fiber: any): number | null {
   const props = fiber.memoizedProps;
-  const line =
-    typeof fiber.type === 'string'
-      ? props?.['data-playroomline']
-      : props?.__playroomLine;
-  return typeof line === 'number' ? line : null;
+  const key =
+    typeof fiber.type === 'string' ? 'data-playroomline' : '__playroomLine';
+  const line = props?.[key];
+  if (typeof line === 'number') {
+    return line;
+  }
+  const altLine = fiber.alternate?.memoizedProps?.[key];
+  return typeof altLine === 'number' ? altLine : null;
 }
 
 function findHostElement(fiber: any): Element | null {

--- a/src/components/Frame/InspectOverlay.tsx
+++ b/src/components/Frame/InspectOverlay.tsx
@@ -269,6 +269,7 @@ export const InspectOverlay = () => {
       )}
       <div
         className={styles.overlay}
+        data-testid="inspect-overlay"
         onMouseMove={handleMouseMove}
         onMouseLeave={handleMouseLeave}
         onClick={handleClick}

--- a/src/components/Frame/InspectOverlay.tsx
+++ b/src/components/Frame/InspectOverlay.tsx
@@ -97,13 +97,18 @@ function findDeepestElementMatch(
 }
 
 function findInspectTarget(el: Element): InspectResult | null {
-  const fiberKey = getFiberKey(el);
-  if (!fiberKey) {
+  let target: Element | null = el;
+  while (target && !getFiberKey(target)) {
+    target = target.parentElement;
+  }
+  if (!target) {
     return null;
   }
 
+  const fiberKey = getFiberKey(target)!;
+
   const fiberPath: any[] = [];
-  let fiber = (el as any)[fiberKey];
+  let fiber = (target as any)[fiberKey];
 
   while (fiber) {
     fiberPath.push(fiber);
@@ -118,7 +123,7 @@ function findInspectTarget(el: Element): InspectResult | null {
         const targetFiber = fiberPath.find((f) => f.type === deeperMatch.type);
         if (targetFiber) {
           const hostEl = findHostElement(targetFiber);
-          if (hostEl) {
+          if (hostEl && hostEl.contains(el)) {
             return { line: deeperMatch.line, element: hostEl };
           }
         }

--- a/src/components/Frame/frameMessenger.tsx
+++ b/src/components/Frame/frameMessenger.tsx
@@ -116,3 +116,59 @@ export const ScreenshotMessageReceiver = () => {
 
   return null;
 };
+
+/**
+ * -------------------
+ *  Inspect Message
+ * -------------------
+ */
+const PlayroomInspectSource = 'Playroom Inspect';
+
+export const inspectMessageSender = ({
+  messageWindow,
+  action,
+}: {
+  messageWindow: Window;
+  action: 'enable' | 'disable';
+}) => {
+  messageWindow.postMessage({ source: PlayroomInspectSource, action }, '*');
+};
+
+interface InspectMessageReceiverProps {
+  onHover: (line: number | null) => void;
+  onSelect: (line: number) => void;
+  onExit: () => void;
+}
+
+export const InspectMessageReceiver = ({
+  onHover,
+  onSelect,
+  onExit,
+}: InspectMessageReceiverProps) => {
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      if (event.data?.source !== PlayroomInspectSource) return;
+
+      switch (event.data.type) {
+        case 'hover':
+          onHover(event.data.line ?? null);
+          break;
+        case 'select':
+          if (typeof event.data.line === 'number') {
+            onSelect(event.data.line);
+          }
+          break;
+        case 'exit':
+          onExit();
+          break;
+      }
+    };
+
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, [onHover, onSelect, onExit]);
+
+  return null;
+};
+
+export { PlayroomInspectSource };

--- a/src/components/Frame/frameMessenger.tsx
+++ b/src/components/Frame/frameMessenger.tsx
@@ -147,7 +147,9 @@ export const InspectMessageReceiver = ({
 }: InspectMessageReceiverProps) => {
   useEffect(() => {
     const handler = (event: MessageEvent) => {
-      if (event.data?.source !== PlayroomInspectSource) return;
+      if (event.data?.source !== PlayroomInspectSource) {
+        return;
+      }
 
       switch (event.data.type) {
         case 'hover':

--- a/src/components/Frame/frameMessenger.tsx
+++ b/src/components/Frame/frameMessenger.tsx
@@ -124,23 +124,31 @@ export const ScreenshotMessageReceiver = () => {
  */
 const PlayroomInspectSource = 'Playroom Inspect';
 
-export const inspectMessageSender = ({
-  messageWindow,
-  action,
-}: {
-  messageWindow: Window;
-  action: 'enable' | 'disable';
-}) => {
-  messageWindow.postMessage({ source: PlayroomInspectSource, action }, '*');
+type InspectMessage =
+  | { type: 'enable' }
+  | { type: 'disable' }
+  | { type: 'hover'; line: number | null }
+  | { type: 'select'; line: number }
+  | { type: 'exit' };
+
+export const inspectMessageSender = (
+  messageWindow: Window,
+  message: InspectMessage
+) => {
+  messageWindow.postMessage({ source: PlayroomInspectSource, ...message });
 };
 
 interface InspectMessageReceiverProps {
-  onHover: (line: number | null) => void;
-  onSelect: (line: number) => void;
-  onExit: () => void;
+  onEnable?: () => void;
+  onDisable?: () => void;
+  onHover?: (line: number | null) => void;
+  onSelect?: (line: number) => void;
+  onExit?: () => void;
 }
 
 export const InspectMessageReceiver = ({
+  onEnable,
+  onDisable,
   onHover,
   onSelect,
   onExit,
@@ -152,25 +160,29 @@ export const InspectMessageReceiver = ({
       }
 
       switch (event.data.type) {
+        case 'enable':
+          onEnable?.();
+          break;
+        case 'disable':
+          onDisable?.();
+          break;
         case 'hover':
-          onHover(event.data.line ?? null);
+          onHover?.(event.data.line ?? null);
           break;
         case 'select':
           if (typeof event.data.line === 'number') {
-            onSelect(event.data.line);
+            onSelect?.(event.data.line);
           }
           break;
         case 'exit':
-          onExit();
+          onExit?.();
           break;
       }
     };
 
     window.addEventListener('message', handler);
     return () => window.removeEventListener('message', handler);
-  }, [onHover, onSelect, onExit]);
+  }, [onEnable, onDisable, onHover, onSelect, onExit]);
 
   return null;
 };
-
-export { PlayroomInspectSource };

--- a/src/components/Frames/Frames.css.ts
+++ b/src/components/Frames/Frames.css.ts
@@ -119,8 +119,13 @@ export const frameActionsContainer = style([
     transition: `opacity ${transitionTiming}`,
     selectors: {
       [`${frameContainer}:not(:hover, :focus-within, ${frameActive}) &`]: {
-        opacity: 0,
+        opacity: 0.3,
+        filter: 'saturate(0)',
       },
+      [`html[data-playroom-dark] ${frameContainer}:not(:hover, :focus-within, ${frameActive}) &`]:
+        {
+          opacity: 0.6,
+        },
     },
   },
 ]);

--- a/src/components/Frames/Frames.tsx
+++ b/src/components/Frames/Frames.tsx
@@ -336,6 +336,7 @@ export default function Frames({ code }: FramesProps) {
 
   const handleInspectSelect = useCallback(
     (line: number) => {
+      dispatch({ type: 'showPanels' });
       dispatch({ type: 'showEditor' });
       dispatch({
         type: 'updateCursorPosition',

--- a/src/components/Frames/Frames.tsx
+++ b/src/components/Frames/Frames.tsx
@@ -27,6 +27,7 @@ import { StoreContext } from '../../contexts/StoreContext';
 import { compileJsx, compileJsxForInspect } from '../../utils/compileJsx';
 import usePreviewUrl from '../../utils/usePreviewUrl';
 import { ButtonIcon } from '../ButtonIcon/ButtonIcon';
+import { primaryMod } from '../CodeEditor/editorCommands';
 import {
   ErrorMessageReceiver,
   InspectMessageReceiver,
@@ -111,7 +112,7 @@ const Frame = ({
     <div
       className={clsx({
         [styles.frameContainer]: true,
-        [styles.frameActive]: frameActive,
+        [styles.frameActive]: frameActive || inspectMode,
       })}
       style={assignInlineVars({
         [styles.frameWidth]:
@@ -135,11 +136,13 @@ const Frame = ({
           <div className={styles.frameActionsContainer}>
             <ButtonIcon
               tone="accent"
-              variant={inspectMode ? 'standard' : 'transparent'}
+              variant="transparent"
+              active={inspectMode}
               size="small"
               bleed
               icon={<Crosshair />}
               label="Inspect element"
+              shortcut={[primaryMod, 'Shift', 'C']}
               onClick={() => {
                 dispatch({
                   type: inspectMode
@@ -333,6 +336,7 @@ export default function Frames({ code }: FramesProps) {
 
   const handleInspectSelect = useCallback(
     (line: number) => {
+      dispatch({ type: 'showEditor' });
       dispatch({
         type: 'updateCursorPosition',
         payload: { position: { line, ch: 0 } },
@@ -356,21 +360,12 @@ export default function Frames({ code }: FramesProps) {
       }
     };
 
-    const handleMouseLeave = () => {
-      dispatch({ type: 'disableInspectMode' });
-    };
-
     const frameId = requestAnimationFrame(() => {
       window.addEventListener('click', handleClick);
-      document.documentElement.addEventListener('mouseleave', handleMouseLeave);
     });
     return () => {
       cancelAnimationFrame(frameId);
       window.removeEventListener('click', handleClick);
-      document.documentElement.removeEventListener(
-        'mouseleave',
-        handleMouseLeave
-      );
     };
   }, [inspectMode, dispatch]);
 

--- a/src/components/Frames/Frames.tsx
+++ b/src/components/Frames/Frames.tsx
@@ -4,13 +4,16 @@ import {
   // Camera,
   // ClipboardCopy,
   // Download,
+  Crosshair,
   PictureInPicture2,
   Settings2,
 } from 'lucide-react';
 import {
   type ReactNode,
   type RefObject,
+  useCallback,
   useContext,
+  useEffect,
   useRef,
   useState,
 } from 'react';
@@ -19,12 +22,15 @@ import type { FrameSettingsValues } from '../../../utils';
 import playroomConfig from '../../config';
 import { themeNames as availableThemes } from '../../configModules/themes';
 import availableWidths, { type Widths } from '../../configModules/widths';
+import { useEditor } from '../../contexts/EditorContext';
 import { StoreContext } from '../../contexts/StoreContext';
-import { compileJsx } from '../../utils/compileJsx';
+import { compileJsx, compileJsxForInspect } from '../../utils/compileJsx';
 import usePreviewUrl from '../../utils/usePreviewUrl';
 import { ButtonIcon } from '../ButtonIcon/ButtonIcon';
 import {
   ErrorMessageReceiver,
+  InspectMessageReceiver,
+  inspectMessageSender,
   // screenshotMessageSender,
 } from '../Frame/frameMessenger';
 import { Menu, MenuCheckboxItem } from '../Menu/Menu';
@@ -53,7 +59,9 @@ const Frame = ({
   scrollingPanelRef,
   frameId,
   frameSettings = {},
+  inspectMode,
   dispatch,
+  registerIframeRef,
 }: {
   frame: { theme: string; width: Widths[number]; widthName: string };
   title?: string;
@@ -61,12 +69,22 @@ const Frame = ({
   scrollingPanelRef: RefObject<HTMLDivElement | null>;
   frameId: string;
   frameSettings: FrameSettingsValues;
+  inspectMode: boolean;
   dispatch: (action: any) => void;
+  registerIframeRef: (frameId: string, el: HTMLIFrameElement | null) => void;
 }) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [frameActive, setFrameActive] = useState(false);
   const noTheme = frame.theme === '__PLAYROOM__NO_THEME__';
   const previewUrl = usePreviewUrl(frame.theme);
+
+  const setIframeRef = useCallback(
+    (el: HTMLIFrameElement | null) => {
+      iframeRef.current = el;
+      registerIframeRef(frameId, el);
+    },
+    [registerIframeRef, frameId]
+  );
 
   // const downloadHandler = () => {
   //   if (iframeRef.current?.contentWindow) {
@@ -115,6 +133,21 @@ const Frame = ({
         )}
         <SharedTooltipContext>
           <div className={styles.frameActionsContainer}>
+            <ButtonIcon
+              tone="accent"
+              variant={inspectMode ? 'standard' : 'transparent'}
+              size="small"
+              bleed
+              icon={<Crosshair />}
+              label="Inspect element"
+              onClick={() => {
+                dispatch({
+                  type: inspectMode
+                    ? 'disableInspectMode'
+                    : 'enableInspectMode',
+                });
+              }}
+            />
             <ButtonIcon
               tone="accent"
               variant="transparent"
@@ -212,7 +245,7 @@ const Frame = ({
       </div>
       <div className={styles.frameWrapper}>
         <Iframe
-          ref={iframeRef}
+          ref={setIframeRef}
           intersectionRootRef={scrollingPanelRef}
           src={frameSrc({
             themeName: frame.theme,
@@ -232,12 +265,17 @@ const Frame = ({
 interface FramesProps {
   code: string;
 }
+
 export default function Frames({ code }: FramesProps) {
-  const [{ selectedWidths, selectedThemes, title, frameSettings }, dispatch] =
-    useContext(StoreContext);
+  const [
+    { selectedWidths, selectedThemes, title, frameSettings, inspectMode },
+    dispatch,
+  ] = useContext(StoreContext);
+  const { scrollToLine, highlightLine } = useEditor();
   const themes = selectedThemes.length > 0 ? selectedThemes : availableThemes;
   const widths = selectedWidths.length > 0 ? selectedWidths : availableWidths;
   const scrollingPanelRef = useRef<HTMLDivElement | null>(null);
+  const iframeRefs = useRef<Map<string, HTMLIFrameElement>>(new Map());
   const renderCode = useRef<string>('');
 
   const frames = widths.flatMap((width) =>
@@ -249,32 +287,125 @@ export default function Frames({ code }: FramesProps) {
   );
 
   try {
-    renderCode.current = compileJsx(code);
+    renderCode.current = inspectMode
+      ? compileJsxForInspect(code)
+      : compileJsx(code);
   } catch {}
-  return (
-    <ScrollContainer
-      ref={scrollingPanelRef}
-      direction="horizontal"
-      fadeSize="small"
-    >
-      <div className={styles.root}>
-        {frames.map((frame) => {
-          const frameId = `${frame.theme}-${frame.width}`;
 
-          return (
-            <Frame
-              key={frameId}
-              frame={frame}
-              code={renderCode.current}
-              title={title}
-              scrollingPanelRef={scrollingPanelRef}
-              frameId={frameId}
-              frameSettings={frameSettings[frameId]}
-              dispatch={dispatch}
-            />
-          );
-        })}
-      </div>
-    </ScrollContainer>
+  const registerIframeRef = useCallback(
+    (frameId: string, el: HTMLIFrameElement | null) => {
+      if (el) {
+        iframeRefs.current.set(frameId, el);
+      } else {
+        iframeRefs.current.delete(frameId);
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    const action = inspectMode ? 'enable' : 'disable';
+    iframeRefs.current.forEach((iframe) => {
+      if (iframe.contentWindow) {
+        inspectMessageSender({
+          messageWindow: iframe.contentWindow,
+          action,
+        });
+      }
+    });
+  }, [inspectMode]);
+
+  const handleInspectHover = useCallback(
+    (line: number | null) => {
+      if (typeof line === 'number') {
+        scrollToLine(line);
+        highlightLine(line);
+      } else {
+        highlightLine(null);
+      }
+    },
+    [scrollToLine, highlightLine]
+  );
+
+  const handleInspectSelect = useCallback(
+    (line: number) => {
+      dispatch({
+        type: 'updateCursorPosition',
+        payload: { position: { line, ch: 0 } },
+      });
+      dispatch({ type: 'disableInspectMode' });
+    },
+    [dispatch]
+  );
+
+  const handleInspectExit = useCallback(() => {
+    dispatch({ type: 'disableInspectMode' });
+    highlightLine(null);
+  }, [dispatch, highlightLine]);
+
+  useEffect(() => {
+    if (!inspectMode) return;
+
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest('iframe')) {
+        dispatch({ type: 'disableInspectMode' });
+      }
+    };
+
+    const handleMouseLeave = () => {
+      dispatch({ type: 'disableInspectMode' });
+    };
+
+    const frameId = requestAnimationFrame(() => {
+      window.addEventListener('click', handleClick);
+      document.documentElement.addEventListener('mouseleave', handleMouseLeave);
+    });
+    return () => {
+      cancelAnimationFrame(frameId);
+      window.removeEventListener('click', handleClick);
+      document.documentElement.removeEventListener(
+        'mouseleave',
+        handleMouseLeave
+      );
+    };
+  }, [inspectMode, dispatch]);
+
+  return (
+    <>
+      {inspectMode && (
+        <InspectMessageReceiver
+          onHover={handleInspectHover}
+          onSelect={handleInspectSelect}
+          onExit={handleInspectExit}
+        />
+      )}
+      <ScrollContainer
+        ref={scrollingPanelRef}
+        direction="horizontal"
+        fadeSize="small"
+      >
+        <div className={styles.root}>
+          {frames.map((frame) => {
+            const frameId = `${frame.theme}-${frame.width}`;
+
+            return (
+              <Frame
+                key={frameId}
+                frame={frame}
+                code={renderCode.current}
+                title={title}
+                scrollingPanelRef={scrollingPanelRef}
+                frameId={frameId}
+                frameSettings={frameSettings[frameId]}
+                inspectMode={inspectMode}
+                dispatch={dispatch}
+                registerIframeRef={registerIframeRef}
+              />
+            );
+          })}
+        </div>
+      </ScrollContainer>
+    </>
   );
 }

--- a/src/components/Frames/Frames.tsx
+++ b/src/components/Frames/Frames.tsx
@@ -352,7 +352,9 @@ export default function Frames({ code }: FramesProps) {
   }, [dispatch]);
 
   useEffect(() => {
-    if (!inspectMode) return;
+    if (!inspectMode) {
+      return;
+    }
 
     const handleClick = (e: MouseEvent) => {
       const target = e.target as HTMLElement;

--- a/src/components/Frames/Frames.tsx
+++ b/src/components/Frames/Frames.tsx
@@ -271,7 +271,7 @@ export default function Frames({ code }: FramesProps) {
     { selectedWidths, selectedThemes, title, frameSettings, inspectMode },
     dispatch,
   ] = useContext(StoreContext);
-  const { scrollToLine, highlightLine } = useEditor();
+  const { scrollToLine, highlightLine, fadeHighlight } = useEditor();
   const themes = selectedThemes.length > 0 ? selectedThemes : availableThemes;
   const widths = selectedWidths.length > 0 ? selectedWidths : availableWidths;
   const scrollingPanelRef = useRef<HTMLDivElement | null>(null);
@@ -313,7 +313,11 @@ export default function Frames({ code }: FramesProps) {
         });
       }
     });
-  }, [inspectMode]);
+
+    if (!inspectMode) {
+      fadeHighlight();
+    }
+  }, [inspectMode, fadeHighlight]);
 
   const handleInspectHover = useCallback(
     (line: number | null) => {
@@ -340,8 +344,7 @@ export default function Frames({ code }: FramesProps) {
 
   const handleInspectExit = useCallback(() => {
     dispatch({ type: 'disableInspectMode' });
-    highlightLine(null);
-  }, [dispatch, highlightLine]);
+  }, [dispatch]);
 
   useEffect(() => {
     if (!inspectMode) return;

--- a/src/components/Frames/Frames.tsx
+++ b/src/components/Frames/Frames.tsx
@@ -305,13 +305,10 @@ export default function Frames({ code }: FramesProps) {
   );
 
   useEffect(() => {
-    const action = inspectMode ? 'enable' : 'disable';
+    const type = inspectMode ? 'enable' : 'disable';
     iframeRefs.current.forEach((iframe) => {
       if (iframe.contentWindow) {
-        inspectMessageSender({
-          messageWindow: iframe.contentWindow,
-          action,
-        });
+        inspectMessageSender(iframe.contentWindow, { type });
       }
     });
 

--- a/src/components/Frames/Frames.tsx
+++ b/src/components/Frames/Frames.tsx
@@ -4,9 +4,9 @@ import {
   // Camera,
   // ClipboardCopy,
   // Download,
-  Crosshair,
   PictureInPicture2,
   Settings2,
+  SquareDashedMousePointerIcon,
 } from 'lucide-react';
 import {
   type ReactNode,
@@ -140,7 +140,7 @@ const Frame = ({
               active={inspectMode}
               size="small"
               bleed
-              icon={<Crosshair />}
+              icon={<SquareDashedMousePointerIcon />}
               label="Inspect element"
               shortcut={[primaryMod, 'Shift', 'C']}
               onClick={() => {

--- a/src/components/Frames/Frames.tsx
+++ b/src/components/Frames/Frames.tsx
@@ -24,7 +24,7 @@ import { themeNames as availableThemes } from '../../configModules/themes';
 import availableWidths, { type Widths } from '../../configModules/widths';
 import { useEditor } from '../../contexts/EditorContext';
 import { StoreContext } from '../../contexts/StoreContext';
-import { compileJsx, compileJsxForInspect } from '../../utils/compileJsx';
+import { compileJsxForInspect } from '../../utils/compileJsx';
 import usePreviewUrl from '../../utils/usePreviewUrl';
 import { ButtonIcon } from '../ButtonIcon/ButtonIcon';
 import { primaryMod } from '../CodeEditor/editorCommands';
@@ -290,9 +290,7 @@ export default function Frames({ code }: FramesProps) {
   );
 
   try {
-    renderCode.current = inspectMode
-      ? compileJsxForInspect(code)
-      : compileJsx(code);
+    renderCode.current = compileJsxForInspect(code);
   } catch {}
 
   const registerIframeRef = useCallback(

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -23,6 +23,7 @@ import {
   Eye,
   EyeClosed,
   ChevronDown,
+  Crosshair,
 } from 'lucide-react';
 import {
   type ComponentProps,
@@ -210,6 +211,7 @@ const HeaderMenu = ({ onShareClick }: { onShareClick: () => void }) => {
       openDialogOpen,
       code,
       id,
+      inspectMode,
     },
     dispatch,
   ] = useContext(StoreContext);
@@ -316,6 +318,20 @@ const HeaderMenu = ({ onShareClick }: { onShareClick: () => void }) => {
             </MenuRadioItem>
           </MenuRadioGroup>
         </Menu>
+
+        <MenuItem
+          icon={Crosshair}
+          onClick={() =>
+            dispatch({
+              type: inspectMode ? 'disableInspectMode' : 'enableInspectMode',
+            })
+          }
+          disabled={!hasCode}
+          disabledReason="No active Playroom to inspect"
+          shortcut={[primaryMod, 'Shift', 'C']}
+        >
+          Inspect
+        </MenuItem>
 
         <MenuItem
           icon={panelsVisible ? Eye : EyeClosed}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -330,7 +330,7 @@ const HeaderMenu = ({ onShareClick }: { onShareClick: () => void }) => {
           disabledReason="No active Playroom to inspect"
           shortcut={[primaryMod, 'Shift', 'C']}
         >
-          Inspect
+          Inspect Element
         </MenuItem>
 
         <MenuItem

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -326,7 +326,6 @@ const HeaderMenu = ({ onShareClick }: { onShareClick: () => void }) => {
               type: inspectMode ? 'disableInspectMode' : 'enableInspectMode',
             })
           }
-          disabled={!hasCode}
           disabledReason="No active Playroom to inspect"
           shortcut={[primaryMod, 'Shift', 'C']}
         >

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -23,7 +23,7 @@ import {
   Eye,
   EyeClosed,
   ChevronDown,
-  Crosshair,
+  SquareDashedMousePointerIcon,
 } from 'lucide-react';
 import {
   type ComponentProps,
@@ -320,7 +320,7 @@ const HeaderMenu = ({ onShareClick }: { onShareClick: () => void }) => {
         </Menu>
 
         <MenuItem
-          icon={Crosshair}
+          icon={SquareDashedMousePointerIcon}
           onClick={() =>
             dispatch({
               type: inspectMode ? 'disableInspectMode' : 'enableInspectMode',

--- a/src/components/RenderCode/RenderCode.tsx
+++ b/src/components/RenderCode/RenderCode.tsx
@@ -7,14 +7,17 @@ import buildScope from '../../configModules/useScope';
 
 interface Props {
   code: string;
+  inspectMode: boolean;
   onError: (error: string) => void;
 }
 
 const EvalCode = ({
   code,
+  inspectMode,
   onSuccess,
 }: {
   code: string;
+  inspectMode: boolean;
   onSuccess?: () => void;
 }) => {
   useLayoutEffect(() => {
@@ -23,10 +26,10 @@ const EvalCode = ({
     }
   }, [onSuccess]);
 
-  return scopeEval(code, buildScope());
+  return scopeEval(code, buildScope(inspectMode));
 };
 
-export default function RenderCode({ code, onError }: Props) {
+export default function RenderCode({ code, inspectMode, onError }: Props) {
   const lastCode = useRef('');
 
   const onSuccess = () => {
@@ -35,7 +38,9 @@ export default function RenderCode({ code, onError }: Props) {
 
   return (
     <ErrorBoundary
-      fallbackRender={() => <EvalCode code={lastCode.current} />}
+      fallbackRender={() => (
+        <EvalCode code={lastCode.current} inspectMode={inspectMode} />
+      )}
       resetKeys={[code]}
       onError={(e) => {
         onError(e.message);
@@ -44,7 +49,7 @@ export default function RenderCode({ code, onError }: Props) {
         onError('');
       }}
     >
-      <EvalCode code={code} onSuccess={onSuccess} />
+      <EvalCode code={code} inspectMode={inspectMode} onSuccess={onSuccess} />
     </ErrorBoundary>
   );
 }

--- a/src/components/Snippets/Snippets.tsx
+++ b/src/components/Snippets/Snippets.tsx
@@ -218,7 +218,9 @@ const Content = ({ searchRef, onSelect }: SnippetsContentProps) => {
   const hasGroups = snippetsByGroup.length > 1;
   const filteredSnippets = useMemo(() => {
     const s = inputValue.trim();
-    if (!s) return null;
+    if (!s) {
+      return null;
+    }
     return allSnippets
       .map((snippet) => ({ snippet, score: scoreSnippet(snippet, s) }))
       .filter(({ score }) => score > 0)

--- a/src/components/globalKeyboardShortcuts.ts
+++ b/src/components/globalKeyboardShortcuts.ts
@@ -45,6 +45,15 @@ export const useGlobalKeyboardShortcutsForWindow = (win: Window | null) => {
             }
             break;
           }
+          case 'c': {
+            if (e.shiftKey) {
+              e.preventDefault();
+              dispatch({
+                type: inspectMode ? 'disableInspectMode' : 'enableInspectMode',
+              });
+            }
+            break;
+          }
         }
         return;
       }

--- a/src/components/globalKeyboardShortcuts.ts
+++ b/src/components/globalKeyboardShortcuts.ts
@@ -5,8 +5,10 @@ import { StoreContext } from '../contexts/StoreContext';
 import { isMac } from '../utils/formatting';
 
 export const useGlobalKeyboardShortcutsForWindow = (win: Window | null) => {
-  const [{ editorHidden, openDialogOpen, snippetsOpen }, dispatch] =
-    useContext(StoreContext);
+  const [
+    { editorHidden, openDialogOpen, snippetsOpen, inspectMode },
+    dispatch,
+  ] = useContext(StoreContext);
   const { runCommand } = useEditor();
   const formattable = !editorHidden && !openDialogOpen && !snippetsOpen;
 
@@ -16,6 +18,12 @@ export const useGlobalKeyboardShortcutsForWindow = (win: Window | null) => {
     }
 
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && inspectMode) {
+        e.preventDefault();
+        dispatch({ type: 'disableInspectMode' });
+        return;
+      }
+
       const cmdOrCtrl = isMac() ? e.metaKey : e.ctrlKey;
 
       if (cmdOrCtrl) {
@@ -47,5 +55,5 @@ export const useGlobalKeyboardShortcutsForWindow = (win: Window | null) => {
     return () => {
       win.removeEventListener('keydown', handleKeyDown);
     };
-  }, [dispatch, formattable, runCommand, win]);
+  }, [dispatch, formattable, inspectMode, runCommand, win]);
 };

--- a/src/configModules/useScope.ts
+++ b/src/configModules/useScope.ts
@@ -8,6 +8,28 @@ import {
 
 import components from './components';
 
+const displayContents = { display: 'contents' };
+
+const inspectCreateElement = (type: any, props: any, ...children: any[]) => {
+  if (props && props.__source) {
+    const { __source, __self, ...restProps } = props;
+    const line = __source.lineNumber - 1;
+    if (typeof type === 'string') {
+      return createElement(
+        type,
+        { ...restProps, 'data-playroom-line': line },
+        ...children
+      );
+    }
+    return createElement(
+      'span',
+      { 'data-playroom-line': line, style: displayContents },
+      createElement(type, restProps, ...children)
+    );
+  }
+  return createElement(type, props, ...children);
+};
+
 export default () => {
   const userScope = {
     ...(userScopeFromConfig() ?? {}),
@@ -29,7 +51,7 @@ export default () => {
   return {
     ...userScope,
     React,
-    [ReactCreateElementPragma]: createElement,
+    [ReactCreateElementPragma]: inspectCreateElement,
     [ReactFragmentPragma]: Fragment,
   };
 };

--- a/src/configModules/useScope.ts
+++ b/src/configModules/useScope.ts
@@ -8,23 +8,16 @@ import {
 
 import components from './components';
 
-const displayContents = { display: 'contents' };
+const INSPECT_LINE_KEY = 'data-playroom-line';
 
 const inspectCreateElement = (type: any, props: any, ...children: any[]) => {
   if (props && props.__source) {
     const { __source, __self, ...restProps } = props;
     const line = __source.lineNumber - 1;
-    if (typeof type === 'string') {
-      return createElement(
-        type,
-        { ...restProps, 'data-playroom-line': line },
-        ...children
-      );
-    }
     return createElement(
-      'span',
-      { 'data-playroom-line': line, style: displayContents },
-      createElement(type, restProps, ...children)
+      type,
+      { ...restProps, [INSPECT_LINE_KEY]: line },
+      ...children
     );
   }
   return createElement(type, props, ...children);

--- a/src/configModules/useScope.ts
+++ b/src/configModules/useScope.ts
@@ -8,20 +8,25 @@ import {
 
 import components from './components';
 
-const inspectCreateElement = (type: any, props: any, ...children: any[]) => {
-  if (props && props.__source) {
-    const { __source, __self, ...restProps } = props;
-    const line = __source.lineNumber - 1;
-    const lineProp =
-      typeof type === 'string'
-        ? { 'data-playroomline': line }
-        : { __playroomLine: line };
-    return createElement(type, { ...restProps, ...lineProp }, ...children);
-  }
-  return createElement(type, props, ...children);
-};
+const createInspectElement =
+  (active: boolean) =>
+  (type: any, props: any, ...children: any[]) => {
+    if (props && props.__source) {
+      const { __source, __self, ...restProps } = props;
+      if (active) {
+        const line = __source.lineNumber - 1;
+        const lineProp = {
+          [typeof type === 'string' ? 'data-playroomline' : '__playroomLine']:
+            line,
+        };
+        return createElement(type, { ...restProps, ...lineProp }, ...children);
+      }
+      return createElement(type, restProps, ...children);
+    }
+    return createElement(type, props, ...children);
+  };
 
-export default () => {
+export default (inspectMode = false) => {
   const userScope = {
     ...(userScopeFromConfig() ?? {}),
     ...components,
@@ -42,7 +47,7 @@ export default () => {
   return {
     ...userScope,
     React,
-    [ReactCreateElementPragma]: inspectCreateElement,
+    [ReactCreateElementPragma]: createInspectElement(inspectMode),
     [ReactFragmentPragma]: Fragment,
   };
 };

--- a/src/configModules/useScope.ts
+++ b/src/configModules/useScope.ts
@@ -8,17 +8,15 @@ import {
 
 import components from './components';
 
-const INSPECT_LINE_KEY = 'data-playroom-line';
-
 const inspectCreateElement = (type: any, props: any, ...children: any[]) => {
   if (props && props.__source) {
     const { __source, __self, ...restProps } = props;
     const line = __source.lineNumber - 1;
-    return createElement(
-      type,
-      { ...restProps, [INSPECT_LINE_KEY]: line },
-      ...children
-    );
+    const lineProp =
+      typeof type === 'string'
+        ? { 'data-playroomline': line }
+        : { __playroomLine: line };
+    return createElement(type, { ...restProps, ...lineProp }, ...children);
   }
   return createElement(type, props, ...children);
 };

--- a/src/contexts/EditorContext.tsx
+++ b/src/contexts/EditorContext.tsx
@@ -1,4 +1,4 @@
-import type { Editor } from 'codemirror';
+import type { Editor, LineHandle } from 'codemirror';
 import {
   type ReactNode,
   createContext,
@@ -12,12 +12,15 @@ import type { EditorCommand } from '../components/CodeEditor/editorCommands';
 interface EditorValue {
   registerEditor: (cm: Editor) => void;
   runCommand: (command: EditorCommand) => void;
+  scrollToLine: (line: number) => void;
+  highlightLine: (line: number | null) => void;
 }
 
 const EditorContext = createContext<EditorValue | null>(null);
 
 export const EditorProvider = ({ children }: { children: ReactNode }) => {
   const editorRef = useRef<Editor | null>(null);
+  const highlightLineRef = useRef<LineHandle | null>(null);
 
   const registerEditor = useCallback((cm: Editor) => {
     editorRef.current = cm;
@@ -32,8 +35,54 @@ export const EditorProvider = ({ children }: { children: ReactNode }) => {
     editorRef.current.execCommand(command);
   }, []);
 
+  const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const scrollToLine = useCallback((line: number) => {
+    if (!editorRef.current) {
+      return;
+    }
+    if (scrollTimerRef.current) {
+      clearTimeout(scrollTimerRef.current);
+    }
+    scrollTimerRef.current = setTimeout(() => {
+      if (!editorRef.current) {
+        return;
+      }
+      const coords = editorRef.current.charCoords({ line, ch: 0 }, 'local');
+      const scrollInfo = editorRef.current.getScrollInfo();
+      const targetTop = coords.top - scrollInfo.clientHeight / 2;
+      editorRef.current.getScrollerElement().scrollTo({
+        top: targetTop,
+        behavior: 'smooth',
+      });
+    }, 150);
+  }, []);
+
+  const highlightLine = useCallback((line: number | null) => {
+    if (!editorRef.current) return;
+
+    if (highlightLineRef.current) {
+      editorRef.current.removeLineClass(
+        highlightLineRef.current,
+        'background',
+        'cm-inspect-highlight'
+      );
+      highlightLineRef.current = null;
+    }
+
+    if (line !== null) {
+      highlightLineRef.current = editorRef.current.addLineClass(
+        line,
+        'background',
+        'cm-inspect-highlight'
+      );
+    }
+  }, []);
+
   return (
-    <EditorContext.Provider value={{ registerEditor, runCommand }}>
+    <EditorContext.Provider
+      value={{ registerEditor, runCommand, scrollToLine, highlightLine }}
+    >
       {children}
     </EditorContext.Provider>
   );

--- a/src/contexts/EditorContext.tsx
+++ b/src/contexts/EditorContext.tsx
@@ -14,6 +14,7 @@ interface EditorValue {
   runCommand: (command: EditorCommand) => void;
   scrollToLine: (line: number) => void;
   highlightLine: (line: number | null) => void;
+  fadeHighlight: () => void;
 }
 
 const EditorContext = createContext<EditorValue | null>(null);
@@ -58,14 +59,26 @@ export const EditorProvider = ({ children }: { children: ReactNode }) => {
     }, 150);
   }, []);
 
+  const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const highlightLine = useCallback((line: number | null) => {
     if (!editorRef.current) return;
+
+    if (fadeTimerRef.current) {
+      clearTimeout(fadeTimerRef.current);
+      fadeTimerRef.current = null;
+    }
 
     if (highlightLineRef.current) {
       editorRef.current.removeLineClass(
         highlightLineRef.current,
         'background',
         'cm-inspect-highlight'
+      );
+      editorRef.current.removeLineClass(
+        highlightLineRef.current,
+        'background',
+        'cm-inspect-highlight-fade'
       );
       highlightLineRef.current = null;
     }
@@ -76,12 +89,50 @@ export const EditorProvider = ({ children }: { children: ReactNode }) => {
         'background',
         'cm-inspect-highlight'
       );
+    } else if (line === null && highlightLineRef.current === null) {
+      return;
     }
+  }, []);
+
+  const fadeHighlight = useCallback(() => {
+    if (!editorRef.current || !highlightLineRef.current) {
+      return;
+    }
+
+    editorRef.current.removeLineClass(
+      highlightLineRef.current,
+      'background',
+      'cm-inspect-highlight'
+    );
+    editorRef.current.addLineClass(
+      highlightLineRef.current,
+      'background',
+      'cm-inspect-highlight-fade'
+    );
+
+    fadeTimerRef.current = setTimeout(() => {
+      if (!editorRef.current || !highlightLineRef.current) {
+        return;
+      }
+      editorRef.current.removeLineClass(
+        highlightLineRef.current,
+        'background',
+        'cm-inspect-highlight-fade'
+      );
+      highlightLineRef.current = null;
+      fadeTimerRef.current = null;
+    }, 1000);
   }, []);
 
   return (
     <EditorContext.Provider
-      value={{ registerEditor, runCommand, scrollToLine, highlightLine }}
+      value={{
+        registerEditor,
+        runCommand,
+        scrollToLine,
+        highlightLine,
+        fadeHighlight,
+      }}
     >
       {children}
     </EditorContext.Provider>

--- a/src/contexts/EditorContext.tsx
+++ b/src/contexts/EditorContext.tsx
@@ -49,12 +49,24 @@ export const EditorProvider = ({ children }: { children: ReactNode }) => {
       if (!editorRef.current) {
         return;
       }
+
+      const rect = editorRef.current
+        .getWrapperElement()
+        .getBoundingClientRect();
+      const topVisibleLine = editorRef.current.lineAtHeight(rect.top, 'window');
+      const bottomVisibleLine = editorRef.current.lineAtHeight(
+        rect.bottom,
+        'window'
+      );
+      const targetLineInView =
+        line > topVisibleLine && line < bottomVisibleLine;
+
       const coords = editorRef.current.charCoords({ line, ch: 0 }, 'local');
       const scrollInfo = editorRef.current.getScrollInfo();
       const targetTop = coords.top - scrollInfo.clientHeight / 2;
       editorRef.current.getScrollerElement().scrollTo({
         top: targetTop,
-        behavior: 'smooth',
+        behavior: targetLineInView ? 'smooth' : 'auto',
       });
     }, 150);
   }, []);

--- a/src/contexts/EditorContext.tsx
+++ b/src/contexts/EditorContext.tsx
@@ -74,7 +74,9 @@ export const EditorProvider = ({ children }: { children: ReactNode }) => {
   const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const highlightLine = useCallback((line: number | null) => {
-    if (!editorRef.current) return;
+    if (!editorRef.current) {
+      return;
+    }
 
     if (fadeTimerRef.current) {
       clearTimeout(fadeTimerRef.current);

--- a/src/contexts/EditorContext.tsx
+++ b/src/contexts/EditorContext.tsx
@@ -58,6 +58,16 @@ export const EditorProvider = ({ children }: { children: ReactNode }) => {
         rect.bottom,
         'window'
       );
+
+      const visibleRange = bottomVisibleLine - topVisibleLine;
+      const topLines = topVisibleLine + visibleRange * 0.1;
+      const bottomLines = bottomVisibleLine - visibleRange * 0.1;
+      const centerLines = line >= topLines && line <= bottomLines;
+
+      if (centerLines) {
+        return;
+      }
+
       const targetLineInView =
         line > topVisibleLine && line < bottomVisibleLine;
 

--- a/src/contexts/StoreContext.tsx
+++ b/src/contexts/StoreContext.tsx
@@ -135,6 +135,7 @@ export type Action =
   | { type: 'updateEditorHeight'; payload: { size: number } }
   | { type: 'updateEditorWidth'; payload: { size: number } }
   | { type: 'togglePanelVisibility' }
+  | { type: 'showPanels' }
   | {
       type: 'updateSelectedThemes';
       payload: { themes: typeof availableThemes };
@@ -406,6 +407,13 @@ const reducer = (state: State, action: Action): State => {
       return {
         ...state,
         panelsVisible: !state.panelsVisible,
+      };
+    }
+
+    case 'showPanels': {
+      return {
+        ...state,
+        panelsVisible: true,
       };
     }
 

--- a/src/contexts/StoreContext.tsx
+++ b/src/contexts/StoreContext.tsx
@@ -86,6 +86,7 @@ interface State {
   previewRenderCode?: string;
   previewEditorCode?: string;
   highlightLineNumber?: number;
+  inspectMode: boolean;
   snippetsOpen: boolean;
   openDialogOpen: boolean;
   hasSyntaxError?: boolean;
@@ -176,7 +177,9 @@ export type Action =
       payload: {
         id: string;
       };
-    };
+    }
+  | { type: 'enableInspectMode' }
+  | { type: 'disableInspectMode' };
 
 const resetPreview = ({
   previewRenderCode,
@@ -529,6 +532,20 @@ const reducer = (state: State, action: Action): State => {
       };
     }
 
+    case 'enableInspectMode': {
+      return {
+        ...state,
+        inspectMode: true,
+      };
+    }
+
+    case 'disableInspectMode': {
+      return {
+        ...state,
+        inspectMode: false,
+      };
+    }
+
     default:
       return state;
   }
@@ -540,6 +557,7 @@ const initialState: State = {
   id: '',
   code: exampleCode,
   cursorPosition: { line: 0, ch: 0 },
+  inspectMode: false,
   snippetsOpen: false,
   openDialogOpen: false,
   editorHidden: false,

--- a/src/css/palettes.ts
+++ b/src/css/palettes.ts
@@ -225,6 +225,7 @@ export const light = {
     tooltip: lightPalette.gray[1000],
     textSelection: lightPalette.blue[400],
     previewBanner: surfaceLight,
+    inspectOverlay: 'hsla(209, 100%, 80%, .5)', // Blue500 at 50% opacity
   },
   border: {
     standard: lightPalette.gray[400],
@@ -275,6 +276,7 @@ export const dark = {
     tooltip: 'hsla(0,0%,0%,1)',
     textSelection: darkPalette.blue[400],
     previewBanner: surfaceLight,
+    inspectOverlay: 'hsla(209, 100%, 80%, .5)', // Blue500 at 50% opacity
   },
   border: {
     standard: darkPalette.gray[400],

--- a/src/css/palettes.ts
+++ b/src/css/palettes.ts
@@ -225,7 +225,7 @@ export const light = {
     tooltip: lightPalette.gray[1000],
     textSelection: lightPalette.blue[400],
     previewBanner: surfaceLight,
-    inspectOverlay: 'hsla(209, 100%, 80%, .5)', // Blue500 at 50% opacity
+    inspectOverlay: transparentize(0.5, lightPalette.blue[500]),
   },
   border: {
     standard: lightPalette.gray[400],
@@ -276,7 +276,7 @@ export const dark = {
     tooltip: 'hsla(0,0%,0%,1)',
     textSelection: darkPalette.blue[400],
     previewBanner: surfaceLight,
-    inspectOverlay: 'hsla(209, 100%, 80%, .5)', // Blue500 at 50% opacity
+    inspectOverlay: transparentize(0.5, darkPalette.blue[500]),
   },
   border: {
     standard: darkPalette.gray[400],

--- a/src/css/sprinkles.css.ts
+++ b/src/css/sprinkles.css.ts
@@ -38,6 +38,7 @@ export const colorPaletteVars = createThemeContract({
     tooltip: null,
     textSelection: null,
     previewBanner: null,
+    inspectOverlay: null,
   },
   border: {
     standard: null,

--- a/src/entries/frame.tsx
+++ b/src/entries/frame.tsx
@@ -1,5 +1,6 @@
 import type { FrameSettingsValues } from '../../utils';
 import Frame from '../components/Frame/Frame';
+import { InspectOverlay } from '../components/Frame/InspectOverlay';
 import {
   ErrorMessageSender,
   ScreenshotMessageReceiver,
@@ -40,6 +41,7 @@ renderElement(
             frameSettings={mergedFrameSettings}
             ErrorComponent={ErrorMessageSender}
           />
+          <InspectOverlay />
         </>
       );
     }}

--- a/src/entries/frame.tsx
+++ b/src/entries/frame.tsx
@@ -1,49 +1,69 @@
+import { useState } from 'react';
+
 import type { FrameSettingsValues } from '../../utils';
 import Frame from '../components/Frame/Frame';
 import { InspectOverlay } from '../components/Frame/InspectOverlay';
 import {
   ErrorMessageSender,
+  InspectMessageReceiver,
   ScreenshotMessageReceiver,
 } from '../components/Frame/frameMessenger';
 import playroomConfig from '../config';
 import { renderElement } from '../render';
 import { UrlParams } from '../utils/params';
 
+const FrameContent = ({
+  code,
+  themeName,
+  theme,
+}: {
+  code: string;
+  themeName: string | null;
+  theme: string;
+}) => {
+  const [inspectMode, setInspectMode] = useState(false);
+
+  const frameSettings = playroomConfig.frameSettings || [];
+  const defaultFrameSettings = frameSettings.reduce((acc, setting) => {
+    acc[setting.id] = setting.defaultValue;
+    return acc;
+  }, {} as FrameSettingsValues);
+
+  const urlParams = new URLSearchParams(window.location.hash.slice(2));
+  const frameSettingsParam = urlParams.get('frameSettings');
+  const parsedFrameSettings = frameSettingsParam
+    ? JSON.parse(frameSettingsParam)
+    : {};
+
+  const mergedFrameSettings = {
+    ...defaultFrameSettings,
+    ...parsedFrameSettings,
+  };
+
+  return (
+    <>
+      <InspectMessageReceiver
+        onEnable={() => setInspectMode(true)}
+        onDisable={() => setInspectMode(false)}
+      />
+      <ScreenshotMessageReceiver />
+      <Frame
+        code={code}
+        inspectMode={inspectMode}
+        themeName={themeName}
+        theme={theme}
+        frameSettings={mergedFrameSettings}
+        ErrorComponent={ErrorMessageSender}
+      />
+      <InspectOverlay />
+    </>
+  );
+};
+
 renderElement(
   <UrlParams>
-    {({ code, themeName, theme }) => {
-      const frameSettings = playroomConfig.frameSettings || [];
-      // Build default frame settings from config
-      const defaultFrameSettings = frameSettings.reduce((acc, setting) => {
-        acc[setting.id] = setting.defaultValue;
-        return acc;
-      }, {} as FrameSettingsValues);
-
-      // Parse frame settings from URL if present
-      const urlParams = new URLSearchParams(window.location.hash.slice(2));
-      const frameSettingsParam = urlParams.get('frameSettings');
-      const parsedFrameSettings = frameSettingsParam
-        ? JSON.parse(frameSettingsParam)
-        : {};
-
-      const mergedFrameSettings = {
-        ...defaultFrameSettings,
-        ...parsedFrameSettings,
-      };
-
-      return (
-        <>
-          <ScreenshotMessageReceiver />
-          <Frame
-            code={code}
-            themeName={themeName}
-            theme={theme}
-            frameSettings={mergedFrameSettings}
-            ErrorComponent={ErrorMessageSender}
-          />
-          <InspectOverlay />
-        </>
-      );
-    }}
+    {({ code, themeName, theme }) => (
+      <FrameContent code={code} themeName={themeName} theme={theme} />
+    )}
   </UrlParams>
 );

--- a/src/utils/compileJsx.ts
+++ b/src/utils/compileJsx.ts
@@ -21,6 +21,16 @@ export const compileJsx = memoizeOne(
     }).code
 );
 
+export const compileJsxForInspect = memoizeOne(
+  (code: string) =>
+    transform(wrapInFragment(code.trim()), {
+      transforms: ['jsx'],
+      jsxPragma: ReactCreateElementPragma,
+      jsxFragmentPragma: ReactFragmentPragma,
+      production: false,
+    }).code
+);
+
 const parseWithBabel = memoizeOne((code: string) =>
   parseExpression(wrapInFragment(code), {
     plugins: ['jsx'],


### PR DESCRIPTION
Introducing an "Inspect element" feature, that allows users to interrogate the rendered content and associate it back to the line of code in Playroom that generated it. Selecting an element will jump to the point in the code (opening the editor if not visible).

<img width="1772" height="1313" alt="Mouse over an element to inspect demo" src="https://github.com/user-attachments/assets/a7a9c8ba-2fa9-4da1-bfc1-f9aa07ed7bee" />

https://github.com/user-attachments/assets/9b6407f5-2fe8-4758-874c-2bc6bb04242a

