### PR TITLE
Support named widths in configuration

### DIFF
--- a/.changeset/bright-walls-name.md
+++ b/.changeset/bright-walls-name.md
@@ -1,0 +1,5 @@
+---
+'playroom': minor
+---
+
+Support named widths in Playroom configuration

--- a/README.md
+++ b/README.md
@@ -84,6 +84,21 @@ module.exports = {
 };
 ```
 
+Widths can also be named by providing an object. The names are displayed in
+the frame selector while width preferences and shared URLs continue to use the
+numeric values.
+
+```js
+module.exports = {
+  // ...
+  widths: {
+    sm: 320,
+    md: 768,
+    lg: 1024,
+  },
+};
+```
+
 _Note: `port` and `openBrowser` options will be set to `9000` and `true` (respectively) by default whenever they are omitted from the config above._
 
 Your `components` file is expected to export a single object or a series of named exports. For example:

--- a/cypress/e2e/mainMenu.cy.ts
+++ b/cypress/e2e/mainMenu.cy.ts
@@ -85,6 +85,16 @@ describe('Main Menu', () => {
   });
 
   describe('Frames', () => {
+    it('Named widths', () => {
+      loadPlayroom();
+      openMainMenuSubMenu('Frames');
+
+      cy.findByRole('menuitemcheckbox', { name: '(sm) 320' }).should('exist');
+      cy.findByRole('menuitemcheckbox', { name: '(md) 375' }).should('exist');
+      cy.findByRole('menuitemcheckbox', { name: '(lg) 768' }).should('exist');
+      cy.findByRole('menuitemcheckbox', { name: '(xl) 1024' }).should('exist');
+    });
+
     it('Widths', () => {
       const widths: Widths = [320, 375, 768, 1024, 'Fit to window'];
       const widthToSelect = widths[1];

--- a/cypress/projects/basic/playroom.config.js
+++ b/cypress/projects/basic/playroom.config.js
@@ -15,6 +15,12 @@ module.exports = {
       defaultValue: false,
     },
   ],
+  widths: {
+    sm: 320,
+    md: 375,
+    lg: 768,
+    xl: 1024,
+  },
   outputPath: './dist',
   openBrowser: false,
   port: 9000,

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -125,7 +125,9 @@ export const selectWidthPreference = (
   options: { source: 'menu' | 'header' }
 ) => {
   toggleFramesMenuForSource(options.source, 'open');
-  cy.findByRole('menuitemcheckbox', { name: `${width}` }).click();
+  cy.findByRole('menuitemcheckbox', {
+    name: typeof width === 'number' ? new RegExp(`${width}$`) : width,
+  }).click();
   toggleFramesMenuForSource(options.source, 'close');
 };
 export const selectThemePreference = (

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -40,7 +40,7 @@ import {
   themeNames,
   themesEnabled,
 } from '../../configModules/themes';
-import availableWidths from '../../configModules/widths';
+import availableWidths, { getWidthName } from '../../configModules/widths';
 import { StoreContext } from '../../contexts/StoreContext';
 import { createUrlForData, resolveDataFromUrl } from '../../utils/params';
 import { useCopy } from '../../utils/useCopy';
@@ -132,28 +132,32 @@ const FramesMenu = () => {
           </MenuClearItem>
         }
       >
-        {availableWidths.map((width) => (
-          <MenuCheckboxItem
-            icon={getIconForWidth(width)}
-            key={width}
-            checked={hasFilteredWidths && selectedWidths.includes(width)}
-            onCheckedChange={(checked: boolean) => {
-              const newWidths =
-                selectedWidths.length === 0 ? [width] : selectedWidths;
+        {availableWidths.map((width) => {
+          const widthName = getWidthName(width);
 
-              dispatch({
-                type: 'updateSelectedWidths',
-                payload: {
-                  widths: checked
-                    ? [...newWidths, width]
-                    : newWidths.filter((w) => w !== width),
-                },
-              });
-            }}
-          >
-            {width}
-          </MenuCheckboxItem>
-        ))}
+          return (
+            <MenuCheckboxItem
+              icon={getIconForWidth(width)}
+              key={width}
+              checked={hasFilteredWidths && selectedWidths.includes(width)}
+              onCheckedChange={(checked: boolean) => {
+                const newWidths =
+                  selectedWidths.length === 0 ? [width] : selectedWidths;
+
+                dispatch({
+                  type: 'updateSelectedWidths',
+                  payload: {
+                    widths: checked
+                      ? [...newWidths, width]
+                      : newWidths.filter((w) => w !== width),
+                  },
+                });
+              }}
+            >
+              {widthName ? `(${widthName}) ${width}` : width}
+            </MenuCheckboxItem>
+          );
+        })}
       </MenuGroup>
 
       {themesEnabled ? (

--- a/src/configModules/widths.test.ts
+++ b/src/configModules/widths.test.ts
@@ -1,0 +1,22 @@
+jest.mock('../config', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+import { normalizeWidths } from './widths';
+
+describe('normalize widths', () => {
+  it('preserves array width configuration', () => {
+    expect(normalizeWidths([320, 768])).toEqual([
+      { width: 320 },
+      { width: 768 },
+    ]);
+  });
+
+  it('preserves names from object width configuration', () => {
+    expect(normalizeWidths({ sm: 320, md: 768 })).toEqual([
+      { name: 'sm', width: 320 },
+      { name: 'md', width: 768 },
+    ]);
+  });
+});

--- a/src/configModules/widths.ts
+++ b/src/configModules/widths.ts
@@ -1,8 +1,28 @@
 import playroomConfig from '../config';
 
 export type Widths = Array<number | 'Fit to window'>;
+export type WidthConfig = number[] | Record<string, number>;
 
-const suppliedWidths = playroomConfig.widths || [320, 375, 768, 1024];
-const widths: Widths = [...suppliedWidths, 'Fit to window'];
+interface WidthOption {
+  name?: string;
+  width: number;
+}
+
+export const normalizeWidths = (widths: WidthConfig): WidthOption[] =>
+  Array.isArray(widths)
+    ? widths.map((width) => ({ width }))
+    : Object.entries(widths).map(([name, width]) => ({ name, width }));
+
+const suppliedWidths = normalizeWidths(
+  playroomConfig.widths || [320, 375, 768, 1024]
+);
+
+export const getWidthName = (width: Widths[number]) =>
+  suppliedWidths.find((option) => option.width === width)?.name;
+
+const widths: Widths = [
+  ...suppliedWidths.map((option) => option.width),
+  'Fit to window',
+];
 
 export default widths;

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -3,14 +3,14 @@ import {
   decompressFromEncodedURIComponent,
 } from 'lz-string';
 
-import type { Widths } from '../src/configModules/widths';
+import type { WidthConfig, Widths } from '../src/configModules/widths';
 
 export interface PlayroomConfig {
   components: string;
   outputPath: string;
   title?: string;
   themes?: string;
-  widths?: number[];
+  widths?: WidthConfig;
   snippets?: string;
   scope?: string;
   typeScriptFiles?: string[];


### PR DESCRIPTION
## What

Allow `widths` to be configured as either the existing number array or a name-to-width object. Named values are shown as labels in the frame selector.

The configuration module previously spread `widths` directly into the available numeric values, so semantic breakpoint names could not survive configuration. This change normalizes both accepted shapes into named width options, while retaining numeric values for selection state, preferences, and shared URLs.

Existing array configuration remains unchanged. A minor changeset and configuration example are included.

Fixes #222.

Credit to @caseymhunt for the clear named-breakpoint use case and mockup.

## Testing

- `pnpm test --runInBand` (30 tests passed)
- `pnpm lint:prettier`
- `pnpm lint:eslint`
- `pnpm lint:tsc`
- `pnpm lint:cypress`
- `pnpm package`
- `pnpm cypress:verify`
- `pnpm cypress` (161 tests across 14 specs passed)