### PR TITLE
Fix snippet insertion with consumer Prettier 3

### DIFF
--- a/.changeset/clean-snippets-format.md
+++ b/.changeset/clean-snippets-format.md
@@ -1,0 +1,5 @@
+---
+'playroom': patch
+---
+
+Prevent a consumer's Prettier 3 dependency from breaking snippet insertion by bundling Playroom's synchronous Prettier implementation.

--- a/lib/makeWebpackConfig.js
+++ b/lib/makeWebpackConfig.js
@@ -45,6 +45,9 @@ module.exports = async (playroomConfig, options) => {
       },
       extensions: ['.mjs', '.tsx', '.ts', '.jsx', '.js', '.json'],
       alias: {
+        'prettier/standalone$': require.resolve('prettier/standalone'),
+        'prettier/parser-babel$': require.resolve('prettier/parser-babel'),
+        'prettier/parser-postcss$': require.resolve('prettier/parser-postcss'),
         __PLAYROOM_ALIAS__COMPONENTS__: relativeResolve(
           playroomConfig.components
         ),

--- a/lib/makeWebpackConfig.test.ts
+++ b/lib/makeWebpackConfig.test.ts
@@ -1,0 +1,32 @@
+import { resolve } from 'node:path';
+
+// @ts-expect-error No types
+import makeWebpackConfig from './makeWebpackConfig';
+
+describe('makeWebpackConfig', () => {
+  it('resolves formatter modules from Playroom', async () => {
+    const config = await makeWebpackConfig(
+      {
+        cwd: resolve(__dirname, '../cypress/projects/basic'),
+        components: './components.js',
+        outputPath: './dist',
+        baseUrl: '',
+        webpackConfig: () => ({
+          resolve: {
+            alias: {
+              prettier: '/consumer/node_modules/prettier',
+            },
+          },
+        }),
+      },
+      { production: true }
+    );
+
+    expect(config.resolve.alias).toMatchObject({
+      'prettier/standalone$': require.resolve('prettier/standalone'),
+      'prettier/parser-babel$': require.resolve('prettier/parser-babel'),
+      'prettier/parser-postcss$': require.resolve('prettier/parser-postcss'),
+      prettier: '/consumer/node_modules/prettier',
+    });
+  });
+});


### PR DESCRIPTION
## What changed

- pin Playroom's `prettier/standalone`, `prettier/parser-babel`, and `prettier/parser-postcss` imports to Playroom's own dependency in the generated webpack config
- use exact aliases so a consumer's broader `prettier` alias remains available to their application without replacing Playroom's formatter
- add regression coverage for a merged consumer config that resolves a different Prettier installation
- add a patch changeset

Fixes #294.

Good catch by @adrienharnay. @askoufis's diagnosis that the consumer's Prettier version was leaking into Playroom was spot on: Prettier 3 returns a promise from `formatWithCursor`, while Playroom's editor formatting path is intentionally synchronous and expects the Prettier 2 result object.

## Compatibility

There is no public API change. Consumer projects can use Prettier 3 while Playroom continues to bundle the synchronous Prettier 2 formatter it declares as a dependency.

## Verification

- consumer-level webpack reproduction with Prettier 3.6.2: the pre-fix bundle returned an asynchronous result; the fixed bundle formatted successfully
- conflicting broad consumer `prettier` alias reproduction: formatted successfully through Playroom's exact aliases
- `jest src lib --runInBand`: 29 tests passed
- `cypress run`: 160 tests passed across 14 specs
- `eslint .`
- `prettier --check '**/*.{js,md,ts,tsx}'`
- `tsc --noEmit`
- `tsc --project cypress/tsconfig.json`
- `tsdown`
- `playroom build --config cypress/projects/basic/playroom.config.js`