### PR TITLE
deps: Fix `typescript` dep range

### DIFF
--- a/.changeset/flat-hornets-drum.md
+++ b/.changeset/flat-hornets-drum.md
@@ -1,0 +1,7 @@
+---
+'playroom': patch
+---
+
+Restrict `typescript` dependency range to `^5.0.0 || ^6.0.0`
+
+Playroom's `typescript` dependency range was previously `>=5.0.0`, but TypeScript's v7 release does not have a compatible API with v5 and v6. The dependency range has been adjust to accurately reflect the versions of TypeScript that Playroom is currently compatible with.

--- a/.changeset/flat-hornets-drum.md
+++ b/.changeset/flat-hornets-drum.md
@@ -4,4 +4,5 @@
 
 Restrict `typescript` dependency range to `^5.0.0 || ^6.0.0`
 
-Playroom's `typescript` dependency range was previously `>=5.0.0`, but TypeScript's v7 release does not have a compatible API with v5 and v6. The dependency range has been adjust to accurately reflect the versions of TypeScript that Playroom is currently compatible with.
+TypeScript v7 does not have a compatible API with v5 and v6.
+The dependency now accurately reflects the supported versions of TypeScript.

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "scope-eval": "^1.0.0",
     "sucrase": "^3.35.1",
     "tinyglobby": "^0.2.12",
-    "typescript": ">=5.0.0",
+    "typescript": "^5.0.0 || ^6.0.0",
     "use-debounce": "^10.0.0",
     "webpack": "^5.75.0",
     "webpack-dev-server": "^5.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,7 +147,7 @@ importers:
         specifier: ^0.2.12
         version: 0.2.14
       typescript:
-        specifier: '>=5.0.0'
+        specifier: ^5.0.0 || ^6.0.0
         version: 5.8.2
       use-debounce:
         specifier: ^10.0.0


### PR DESCRIPTION
[TypeScript v7 has no programmatic API yet](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#:~:text=it%20does%20not%20ship%20with%20an%20API), but we rely on it in `getStaticTypes.js`. The API is slated for 7.1, but will definitely have a different shape to the existing API. Until then, we should restrict our compatible version range to reflect this, as any consumer that resolves to v7 will run into build errors.