### PR TITLE
Update inspect element shortcut

### DIFF
--- a/.changeset/curly-apples-swim.md
+++ b/.changeset/curly-apples-swim.md
@@ -1,0 +1,7 @@
+---
+'playroom': patch
+---
+
+**Inspect**: Change keyboard shortcut to `Cmd/Ctrl+Shift+E`
+
+Avoids conflicting with the browser's native Inspect Element shortcut

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -601,7 +601,7 @@ export const toggleInspectMode = (options: {
       break;
     }
     case 'keyboard': {
-      cy.get('body').type(cmdPlus('shift+c'));
+      cy.get('body').type(cmdPlus('shift+e'));
       break;
     }
     default: {

--- a/src/components/Frames/Frames.tsx
+++ b/src/components/Frames/Frames.tsx
@@ -142,7 +142,7 @@ const Frame = ({
               bleed
               icon={<SquareDashedMousePointerIcon />}
               label="Inspect element"
-              shortcut={[primaryMod, 'Shift', 'C']}
+              shortcut={[primaryMod, 'Shift', 'E']}
               onClick={() => {
                 dispatch({
                   type: inspectMode

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -327,7 +327,7 @@ const HeaderMenu = ({ onShareClick }: { onShareClick: () => void }) => {
             })
           }
           disabledReason="No active Playroom to inspect"
-          shortcut={[primaryMod, 'Shift', 'C']}
+          shortcut={[primaryMod, 'Shift', 'E']}
         >
           Inspect Element
         </MenuItem>

--- a/src/components/globalKeyboardShortcuts.ts
+++ b/src/components/globalKeyboardShortcuts.ts
@@ -45,7 +45,7 @@ export const useGlobalKeyboardShortcutsForWindow = (win: Window | null) => {
             }
             break;
           }
-          case 'c': {
+          case 'e': {
             if (e.shiftKey) {
               e.preventDefault();
               dispatch({


### PR DESCRIPTION
The previous shortcut `Cmd/Ctrl+Shift+C` conflicts with the browser's native "Inspect Element" devtools shortcut, making it unreliable in browser-based environments.

This updates the keyboard shortcut for Inspect Element from `Cmd/Ctrl+Shift+C` to `Cmd/Ctrl+Shift+E`