### PR TITLE
`utils`: Improve ESM compatibility

### DIFF
--- a/.changeset/bitter-kiwis-float.md
+++ b/.changeset/bitter-kiwis-float.md
@@ -1,0 +1,5 @@
+---
+'playroom': patch
+---
+
+`utils`: Improve ESM compatibility

--- a/src/utils/params.ts
+++ b/src/utils/params.ts
@@ -1,4 +1,5 @@
 import { createBrowserHistory } from 'history';
+// Use a default import for better compatibility with ESM consumers
 import lzString from 'lz-string';
 import { useState, useEffect, type ReactNode } from 'react';
 

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,7 +1,5 @@
-import {
-  compressToEncodedURIComponent,
-  decompressFromEncodedURIComponent,
-} from 'lz-string';
+// Use a default import for better compatibility with ESM consumers
+import lzString from 'lz-string';
 
 import type { Widths } from '../src/configModules/widths';
 
@@ -68,7 +66,7 @@ export const compressParams = ({
     ...(editorHidden ? { editorHidden } : {}),
   });
 
-  return compressToEncodedURIComponent(data);
+  return lzString.compressToEncodedURIComponent(data);
 };
 
 export const decompressParams = (param: string | null) => {
@@ -80,7 +78,7 @@ export const decompressParams = (param: string | null) => {
     theme,
     editorHidden,
   }: CompressParamsOptions = param
-    ? JSON.parse(decompressFromEncodedURIComponent(param))
+    ? JSON.parse(lzString.decompressFromEncodedURIComponent(param))
     : {};
 
   return {


### PR DESCRIPTION
`lzString` doesn't have great ESM compatibility, and `tsdown`'s bundling can't quite paper over that unfortunately. This manifests as a runtime error in some situations - in particular this is blocking Braid's docs site from moving to Vite.

Luckily the fix is straightforward: only use `lz-string`'s default export. This fix has been validated in the Braid site.

## Alternative solutions

We _could_ move to a different dependency that implements the same compression functionality as `lz-string`, but I haven't found a suitable replacement yet. Alternatively we could use a different compression algorithm entirely, but that would likely break existing playroom links. So for now I think this is the simplest workaround.