### PR TITLE
e2e: Reduce cypress flakiness

### DIFF
--- a/.changeset/brave-ducks-reply.md
+++ b/.changeset/brave-ducks-reply.md
@@ -1,0 +1,7 @@
+---
+'playroom': patch
+---
+
+**Duplicate**: Prefer the current title from app state when building the duplicate URL
+
+Avoids using a stale title from the URL while the debounced URL update is still pending.

--- a/cypress.config.mjs
+++ b/cypress.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   defaultCommandTimeout: 10000,
+  retries: { openMode: 0, runMode: 2 },
   video: false,
   e2e: {},
 });

--- a/cypress/e2e/mainMenu.cy.ts
+++ b/cypress/e2e/mainMenu.cy.ts
@@ -51,9 +51,7 @@ describe('Main Menu', () => {
   });
 
   it('Duplicate playroom', () => {
-    cy.visit(
-      'http://localhost:9000/#?code=N4Igxg9gJgpiBcIA8ALAjAPgCowM4BcACAYWhiQHp0MQAaEfFGAWzwQG0BdegdwEsojXB24M%2B%2BADZxEOAoSzipIAL5A'
-    );
+    loadPlayroom('<h1>Test Code</h1>', { title: 'Test Title' });
     assertCodePaneContains('<h1>Test Code</h1>');
     openMainMenu();
     cy.findByRole('link', { name: 'Duplicate' }).then((link) => {

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -315,14 +315,16 @@ export const selectNextLines = (
 
 export const assertCodePaneContains = (text: string) => {
   getCodeEditor().within(() => {
-    // Accumulate text from individual line elements as they don't include line numbers
-    const lines: string[] = [];
-    cy.get('.CodeMirror-line').each(($el) => lines.push($el.text()));
-
-    cy.then(() => {
+    // Assert inside `.should` so Cypress retries while CodeMirror paints.
+    // Line elements are used so gutter line numbers are excluded.
+    cy.get('.CodeMirror-line').should((lines) => {
       // removes code mirrors invisible last line character placeholder
       // which is inserted to preserve prettier's new line at end of string.
-      const code = lines.join('\n').replace(/[\u200b]$/, '');
+      const code = lines
+        .toArray()
+        .map((el) => el.textContent ?? '')
+        .join('\n')
+        .replace(/[\u200b]$/, '');
       expect(code).to.equal(text);
     });
   });
@@ -375,10 +377,23 @@ export const assertPreviewContains = (text: string) =>
       expect(frameBody.innerText).to.eq(text);
     });
 
-const _loadPlayroom = (baseUrl: string, initialCode?: string) => {
-  const visitUrl = initialCode
-    ? createUrl({ baseUrl, code: dedent(initialCode) })
-    : baseUrl;
+type LoadPlayroomOptions = {
+  title?: string;
+};
+
+const _loadPlayroom = (
+  baseUrl: string,
+  initialCode?: string,
+  options?: LoadPlayroomOptions
+) => {
+  const visitUrl =
+    initialCode || options?.title
+      ? createUrl({
+          baseUrl,
+          ...(initialCode ? { code: dedent(initialCode) } : {}),
+          ...(options?.title ? { title: options.title } : {}),
+        })
+      : baseUrl;
 
   return cy.visit(visitUrl).then((window) => {
     if (!initialCode) {
@@ -389,11 +404,15 @@ const _loadPlayroom = (baseUrl: string, initialCode?: string) => {
     indexedDB.deleteDatabase(storageKey);
   });
 };
-export const loadPlayroom = (initialCode?: string) =>
-  _loadPlayroom('http://localhost:9000', initialCode);
+export const loadPlayroom = (
+  initialCode?: string,
+  options?: LoadPlayroomOptions
+) => _loadPlayroom('http://localhost:9000', initialCode, options);
 
-export const loadThemedPlayroom = (initialCode?: string) =>
-  _loadPlayroom('http://localhost:9001', initialCode);
+export const loadThemedPlayroom = (
+  initialCode?: string,
+  options?: LoadPlayroomOptions
+) => _loadPlayroom('http://localhost:9001', initialCode, options);
 
 export const loadPlayroomWithAppearance = (
   appearance: 'light' | 'dark',

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -212,12 +212,14 @@ const HeaderMenu = ({ onShareClick }: { onShareClick: () => void }) => {
       code,
       id,
       inspectMode,
+      title: storeTitle,
     },
     dispatch,
   ] = useContext(StoreContext);
 
   const hasCode = code.trim().length > 0;
-  const { title, ...params } = resolveDataFromUrl();
+  const { title: urlTitle, ...params } = resolveDataFromUrl();
+  const title = storeTitle || urlTitle;
   const duplicateUrl = createUrlForData(
     compressParams({
       ...params,


### PR DESCRIPTION
A handful of fixes that should hopefully make cypress tests a bit less flakey 🤞:

- Prefer store title over URL title when building the Duplicate link (avoids URL debounce timer)
- Make `assertCodePaneContains` retry inside `.should()` while CodeMirror paints
- Retry tests up to 2 times in run mode (CI/headless)